### PR TITLE
feat(web): complete Base wallet portfolio, sends and swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ Open the local URL printed by Vite. When actively changing shared packages, run
 See [`apps/farcaster-web/README.md`](./apps/farcaster-web/README.md) for web-only
 commands and configuration details.
 
+## Cloudflare Pages deployment
+
+Demo: [farcaster-wallet-client.pages.dev](https://farcaster-wallet-client.pages.dev/).
+
+The hosted client needs both the web build and the same-origin API relay in
+`functions/~api/[[path]].ts`. Uploading only the static build is not enough for
+hosted Farcaster login. The relay forwards API requests to Farcaster; this fork
+does not include an independent Farcaster backend.
+
+Use Cloudflare Pages Git integration with the repository root as the build
+root. See the [deployment guide](./apps/farcaster-web/README.md#cloudflare-pages-deployment)
+for exact build settings, environment variables, login checks, and limitations.
+
 ## Validation
 
 ```sh
@@ -106,7 +119,10 @@ miniapp transactions, sends, swaps, and rejected approvals.
 - Built-in swaps currently target Base.
 - The send screen currently sends the connected chain's native token.
 - Swap execution depends on LI.FI route availability and downstream liquidity.
-- Local Farcaster sessions use the current production Farcaster API.
+- Local development uses the production Farcaster API directly by default;
+  hosted builds use it through the same-origin relay. This is not a sandbox.
+- Some miniapps restrict embedding or trusted client origins. The API relay
+  does not remove those restrictions; compatibility depends on each miniapp.
 
 ## Upstream snapshot
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ in their own wallet.
 - Automatic discovery of modern EIP-6963 browser wallets
 - One persistent wallet across the dashboard and Farcaster miniapps
 - EIP-1193 provider support for miniapp signatures and transactions
-- Connected address and native-token balance
+- Connected address, native ETH balance, and Base token portfolio
 - Receive address with QR code and copy action
-- Native-token sending
+- ETH and ERC-20 sending on Base, with live balance checks
 - Base swaps between ETH and arbitrary Base ERC-20 contract addresses
 - Quote, route, minimum received, allowance, approval, and transaction handling
 - Explicit disconnect and reconnect flow
@@ -33,6 +33,13 @@ phrase or private key is created, requested, or stored by this client.
 
 Base swap quotes and transaction requests come from the public LI.FI quote API.
 The connected wallet remains responsible for approvals and transaction signing.
+
+LI.FI also supplies wallet token discovery, token metadata, and estimated prices.
+Portfolio, Send, and Trade share one cache keyed by Base + wallet + token contract.
+Displayed quantities are checked onchain rather than trusting indexed holdings;
+preflight reads update that same cache before sending or swapping. Farcaster's
+wallet positions API is not used by these screens. See the web README for
+[wallet data sources and limitations](apps/farcaster-web/README.md#wallet-data-sources).
 
 ## Requirements
 
@@ -117,7 +124,10 @@ miniapp transactions, sends, swaps, and rejected approvals.
 - Wallet additions currently target the web client; the mobile client remains
   the upstream snapshot implementation.
 - Built-in swaps currently target Base.
-- The send screen currently sends the connected chain's native token.
+- Portfolio, receive guidance, sends, and swaps currently target Base. Miniapps
+  continue to use the shared wallet provider for their own supported networks.
+- Token discovery/pricing depends on LI.FI coverage; unknown tokens or prices may
+  be unavailable. Transfer history is not implemented in this dashboard yet.
 - Swap execution depends on LI.FI route availability and downstream liquidity.
 - Local development uses the production Farcaster API directly by default;
   hosted builds use it through the same-origin relay. This is not a sandbox.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,120 @@
-# Farcaster Client Snapshot
+# Farcaster Wallet Client
 
-A snapshot of the Farcaster client monorepo codebase without the Farcaster Wallet implementation.
+A fork of the [Farcaster client snapshot](https://github.com/farcasterxyz/client)
+that adds a non-custodial wallet experience to the web client.
 
-This is designed to be a reference for building a social client on top of the Farcaster protocol. Both mobile and web clients run locally, pointing to the current production API by Farcaster.
+The original snapshot intentionally excludes the Farcaster Wallet
+implementation. This fork fills that gap with external wallets: users keep
+control of their keys and approve every connection, signature, and transaction
+in their own wallet.
 
-## Getting Started
+## Wallet features
 
-In the project root, install dependencies and start watching shared packages:
+- WalletConnect support for QR, mobile, browser, and wallet-directory flows
+- Automatic discovery of modern EIP-6963 browser wallets
+- One persistent wallet across the dashboard and Farcaster miniapps
+- EIP-1193 provider support for miniapp signatures and transactions
+- Connected address and native-token balance
+- Receive address with QR code and copy action
+- Native-token sending
+- Base swaps between ETH and arbitrary Base ERC-20 contract addresses
+- Quote, route, minimum received, allowance, approval, and transaction handling
+- Explicit disconnect and reconnect flow
 
+## How it works
+
+The web client uses Wagmi for connection state and exposes the selected wallet
+through the client's existing wallet context. Miniapps, the wallet dashboard,
+sends, and swaps all consume that same provider and address.
+
+WalletConnect is the universal fallback. Compatible browser extensions are
+discovered through EIP-6963 and displayed as direct connection options. No seed
+phrase or private key is created, requested, or stored by this client.
+
+Base swap quotes and transaction requests come from the public LI.FI quote API.
+The connected wallet remains responsible for approvals and transaction signing.
+
+## Requirements
+
+- Node.js 20.19.5 (see `.node-version`)
+- pnpm 10.8.1 (declared in `package.json`)
+- A Reown project ID for WalletConnect
+
+## Web quick start
+
+Clone your fork and install the workspace:
+
+```sh
+git clone git@github.com:YOUR_ACCOUNT/farcaster-wallet-client.git
+cd farcaster-wallet-client
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build:packages
 ```
-pnpm install && pnpm watch
+
+Configure WalletConnect:
+
+```sh
+cp apps/farcaster-web/.env.example apps/farcaster-web/.env.local
 ```
 
-Then in a new terminal, run your preferred client:
+Set the public Reown project identifier in `.env.local`:
 
-### Mobile
-
-```
-cd apps/farcaster-mobile
-pnpm install
-pnpm ios
+```env
+VITE_WALLETCONNECT_PROJECT_ID=your_reown_project_id
 ```
 
-### Web
+Then start the web client:
 
-```
-cd apps/farcaster-web
-pnpm install
-pnpm start
+```sh
+pnpm --filter farcaster-web dev
 ```
 
-## Contributing
+Open the local URL printed by Vite. When actively changing shared packages, run
+`pnpm watch` in another terminal.
 
-This repository is a one-way, automatically generated snapshot of the Farcaster client monorepo. Each update replaces `main` with a single fresh commit, so pull requests and issues opened here can't be merged or tracked, and any change pushed directly is overwritten by the next snapshot.
+See [`apps/farcaster-web/README.md`](./apps/farcaster-web/README.md) for web-only
+commands and configuration details.
 
-Fork it and build on it — that's what it's here for.
+## Validation
+
+```sh
+pnpm --filter farcaster-web typecheck
+pnpm --filter farcaster-web lint
+pnpm --filter farcaster-web test
+pnpm --filter farcaster-web build
+```
+
+The wallet flows have also been exercised manually with WalletConnect, a
+browser with no injected wallet, detected browser wallets, page refreshes,
+miniapp transactions, sends, swaps, and rejected approvals.
+
+## Security notes
+
+- Never enter a seed phrase or private key into this client.
+- Verify token contract addresses before requesting swap quotes.
+- Review the destination, value, chain, allowance, and calldata in the connected
+  wallet before approving.
+- Arbitrary tokens and external routing APIs may be unavailable, illiquid, or
+  malicious.
+- Use a low-value wallet while developing or testing.
+
+## Current scope
+
+- Wallet additions currently target the web client; the mobile client remains
+  the upstream snapshot implementation.
+- Built-in swaps currently target Base.
+- The send screen currently sends the connected chain's native token.
+- Swap execution depends on LI.FI route availability and downstream liquidity.
+- Local Farcaster sessions use the current production Farcaster API.
+
+## Upstream snapshot
+
+This repository began as a snapshot of the Farcaster client monorepo. The
+original snapshot is a one-way generated reference whose `main` branch may be
+replaced by future snapshots. This fork maintains its wallet changes separately;
+review upstream snapshot updates before merging them.
 
 ## License
 
-See [LICENSE](./LICENSE).
+MIT. See [`LICENSE`](./LICENSE).

--- a/apps/farcaster-web/.env.example
+++ b/apps/farcaster-web/.env.example
@@ -1,0 +1,2 @@
+# Public project identifier from the Reown dashboard.
+VITE_WALLETCONNECT_PROJECT_ID=your_reown_project_id

--- a/apps/farcaster-web/README.md
+++ b/apps/farcaster-web/README.md
@@ -62,6 +62,111 @@ pnpm --filter farcaster-web lint
 pnpm --filter farcaster-web build
 ```
 
+## Cloudflare Pages deployment
+
+Use a Git-integrated **Cloudflare Pages** project for this repository. The
+deployment includes the static web app and a Pages Function for Farcaster API
+requests. No mobile build is needed.
+
+### Build settings
+
+Connect your GitHub fork, then configure:
+
+| Setting | Value |
+| --- | --- |
+| Production branch | `main` (or the branch containing the wallet and relay changes) |
+| Framework preset | None |
+| Root directory | Leave blank: repository root |
+| Build command | `pnpm build:packages && pnpm --filter farcaster-web build` |
+| Build output directory | `apps/farcaster-web/dist` |
+
+Do not set the root directory to `apps/farcaster-web`: this repository keeps
+`functions/` at the repository root. Pages discovers Functions relative to the
+project root, not the static output directory. Use Git integration rather than
+uploading the `dist` folder through the dashboard. See Cloudflare's
+[Functions deployment guide](https://developers.cloudflare.com/pages/functions/get-started/).
+
+### Build environment variables
+
+Set these in Cloudflare before deploying:
+
+| Variable | Value |
+| --- | --- |
+| `NODE_VERSION` | `20.19.5` |
+| `PNPM_VERSION` | `10.8.1` |
+| `VITE_WALLETCONNECT_PROJECT_ID` | Your own Reown project ID |
+
+Cloudflare does not receive your ignored `.env.local` file. The `VITE_` project
+ID is public client configuration and is embedded at build time; redeploy after
+changing it. Never put private keys or secret API credentials in `VITE_`
+variables. Configure Preview variables separately if you use branch previews.
+See Cloudflare's [build environment reference](https://developers.cloudflare.com/pages/configuration/build-image/).
+
+Deploy, then add the resulting origin (for example,
+`https://YOUR_PROJECT.pages.dev`) to your Reown project's allowed origins.
+Include custom domains and preview origins you intend to test. This setting
+controls WalletConnect access; it does not fix Farcaster API CORS errors.
+
+The project's production `pages.dev` URL stays the same across deployments.
+Pushes to the configured production branch trigger production builds; an
+unmerged feature branch does not update `main`'s deployment. When switching
+the production branch, ensure it includes both wallet changes and the relay.
+
+### Why the API relay is required
+
+Direct browser requests from our hosted domain to
+`https://farcaster.xyz/~api` were rejected by the upstream CORS policy, which
+prevented login. Production builds now request `/~api/...` on their own origin.
+The Pages Function at [`functions/~api/[[path]].ts`](../../functions/~api/[[path]].ts)
+forwards those requests to the fixed Farcaster upstream host.
+
+- Development mode still uses the upstream API directly by default.
+- Production API routing is selected in [`src/constants/api.ts`](./src/constants/api.ts).
+- WebSockets still connect directly to `wss://ws.farcaster.xyz/stream`.
+- WalletConnect, LI.FI, and chain RPC requests are not routed through this relay.
+- No database, storage binding, or extra relay secret is required by this code.
+
+The relay forwards authorization and Farcaster device headers transiently. It
+removes cookies and the listed origin/forwarding headers from requests, strips
+upstream `Set-Cookie` and CORS response headers, and returns
+`Cache-Control: no-store`. It does not explicitly log or persist request bodies
+or credentials. That is not a claim that the whole deployment has no logging:
+the host processes authentication tokens, platform request logs may exist, and
+the upstream client's analytics remain separate from the relay.
+
+This is an independent client using Farcaster's production services, not an
+isolated test backend. Logins and account actions are real, and availability
+depends on upstream access. Static-only hosts such as GitHub Pages cannot run
+this Function; another host needs an equivalent server-side relay.
+
+### Verify a deployment
+
+1. Confirm the successful deployment uses the intended branch and commit and
+   includes the Pages Function, not just static files.
+2. Open the production URL and test Farcaster sign-in.
+3. In the browser's Network panel, confirm API calls use your domain's
+   `/~api/` path and return API responses, not the app's HTML page. Do not share
+   authorization headers or login tokens when reporting errors.
+4. Connect an external wallet, confirm the dashboard address, and test that a
+   compatible miniapp sees the same account. Reject a transaction request to
+   check the approval flow without spending funds.
+5. Refresh and check session restoration. Also test direct navigation to a
+   client route.
+
+Serving a production build with a static-only preview server does not run
+Pages Functions, so it is not a complete test of hosted login.
+
+### Miniapp domain compatibility
+
+The relay fixes our client's Farcaster API requests, not every miniapp's domain
+requirements. A miniapp may restrict embedding through CSP `frame-ancestors`
+or `X-Frame-Options`, enforce trusted origins in its messaging, or restrict API
+access with CORS. Inspect the actual browser error before choosing a fix.
+
+Miniapp owners may need to allow your client origin. Adding the origin to
+Reown does not grant that permission. Do not strip third-party security headers
+or assume every miniapp will work on a fork's domain.
+
 ## Wallet behavior
 
 - The active external wallet is persisted as the preferred wallet.
@@ -89,6 +194,15 @@ approval and swap signing always occur in the connected wallet.
 - If a browser wallet does not appear, confirm it supports EIP-6963 and is
   enabled for the local site.
 - If a stale local Farcaster login produces repeated `401` responses, clear
-  website data only for the local Vite origin, reload, and sign in again.
+  website data only for the affected client origin, reload, and sign in again.
+- If hosted login reports CORS errors for `farcaster.xyz/~api`, check that the
+  deployed commit includes the relay and production API routing. Rebuilding
+  with only a Reown origin change will not resolve this.
+- If your domain's `/~api/` requests return `404` or HTML, check the Pages root
+  directory and Function deployment. A green static build alone is not enough.
+- If the app works locally but WalletConnect is missing on the hosted site,
+  set the build variable in Cloudflare and redeploy.
+- If only a miniapp is blank, inspect its embedding/trusted-origin errors; see
+  [Miniapp domain compatibility](#miniapp-domain-compatibility).
 - When testing arbitrary tokens, confirm the contract is on Base and has a
   viable route and sufficient liquidity.

--- a/apps/farcaster-web/README.md
+++ b/apps/farcaster-web/README.md
@@ -1,46 +1,94 @@
-# Getting Started with Create React App
+# Farcaster Web
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+The Farcaster web client with external wallet support through WalletConnect and
+detected EIP-6963 browser wallets.
 
-## Available Scripts
+## Setup
 
-In the project directory, you can run:
+Install and build the workspace from the repository root:
 
-### `npm start`
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm build:packages
+```
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Copy the example environment file:
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+```sh
+cp apps/farcaster-web/.env.example apps/farcaster-web/.env.local
+```
 
-### `npm test`
+Add the public project identifier from the
+[Reown dashboard](https://dashboard.reown.com/):
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+```env
+VITE_WALLETCONNECT_PROJECT_ID=your_reown_project_id
+```
 
-### `npm run build`
+The local file is ignored by Git. Configure the same variable in the production
+hosting environment and allow the relevant local and production origins in the
+Reown project settings.
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+WalletConnect requires this project ID. Modern browser extensions can also be
+discovered automatically through EIP-6963.
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+## Development
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+From the repository root:
 
-### `npm run eject`
+```sh
+pnpm --filter farcaster-web dev
+```
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+Open the URL printed by Vite. If you are editing shared workspace packages, run
+`pnpm watch` in another terminal.
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+## Commands
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+```sh
+# Development server
+pnpm --filter farcaster-web dev
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+# Development server with HTTPS enabled explicitly
+pnpm --filter farcaster-web start
 
-## Learn More
+# Tests and static checks
+pnpm --filter farcaster-web test
+pnpm --filter farcaster-web typecheck
+pnpm --filter farcaster-web lint
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+# Production build
+pnpm --filter farcaster-web build
+```
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+## Wallet behavior
+
+- The active external wallet is persisted as the preferred wallet.
+- The same provider and address are used by the wallet dashboard and miniapps.
+- Installed EIP-6963 wallets appear as direct choices.
+- WalletConnect remains available for QR, mobile, browser, and hardware-wallet
+  workflows.
+- Disconnecting returns the dashboard to the connection choices.
+- Private keys and seed phrases never enter the Farcaster client.
+
+## Built-in wallet actions
+
+- View the connected address and native balance
+- Receive with an address QR code
+- Send the connected chain's native token
+- Swap ETH and arbitrary ERC-20 tokens on Base
+
+Base swap quotes and transaction requests use LI.FI's public quote API. Token
+approval and swap signing always occur in the connected wallet.
+
+## Troubleshooting
+
+- If WalletConnect is unavailable, verify
+  `VITE_WALLETCONNECT_PROJECT_ID` and the allowed Reown project origins.
+- If a browser wallet does not appear, confirm it supports EIP-6963 and is
+  enabled for the local site.
+- If a stale local Farcaster login produces repeated `401` responses, clear
+  website data only for the local Vite origin, reload, and sign in again.
+- When testing arbitrary tokens, confirm the contract is on Base and has a
+  viable route and sufficient liquidity.

--- a/apps/farcaster-web/README.md
+++ b/apps/farcaster-web/README.md
@@ -72,13 +72,13 @@ requests. No mobile build is needed.
 
 Connect your GitHub fork, then configure:
 
-| Setting | Value |
-| --- | --- |
-| Production branch | `main` (or the branch containing the wallet and relay changes) |
-| Framework preset | None |
-| Root directory | Leave blank: repository root |
-| Build command | `pnpm build:packages && pnpm --filter farcaster-web build` |
-| Build output directory | `apps/farcaster-web/dist` |
+| Setting                | Value                                                          |
+| ---------------------- | -------------------------------------------------------------- |
+| Production branch      | `main` (or the branch containing the wallet and relay changes) |
+| Framework preset       | None                                                           |
+| Root directory         | Leave blank: repository root                                   |
+| Build command          | `pnpm build:packages && pnpm --filter farcaster-web build`     |
+| Build output directory | `apps/farcaster-web/dist`                                      |
 
 Do not set the root directory to `apps/farcaster-web`: this repository keeps
 `functions/` at the repository root. Pages discovers Functions relative to the
@@ -90,10 +90,10 @@ uploading the `dist` folder through the dashboard. See Cloudflare's
 
 Set these in Cloudflare before deploying:
 
-| Variable | Value |
-| --- | --- |
-| `NODE_VERSION` | `20.19.5` |
-| `PNPM_VERSION` | `10.8.1` |
+| Variable                        | Value                     |
+| ------------------------------- | ------------------------- |
+| `NODE_VERSION`                  | `20.19.5`                 |
+| `PNPM_VERSION`                  | `10.8.1`                  |
 | `VITE_WALLETCONNECT_PROJECT_ID` | Your own Reown project ID |
 
 Cloudflare does not receive your ignored `.env.local` file. The `VITE_` project
@@ -179,13 +179,53 @@ or assume every miniapp will work on a fork's domain.
 
 ## Built-in wallet actions
 
-- View the connected address and native balance
+- View the connected address, native ETH, and Base ERC-20 balances
 - Receive with an address QR code
-- Send the connected chain's native token
+- Send ETH and ERC-20 tokens on Base with exact integer amounts and live checks
 - Swap ETH and arbitrary ERC-20 tokens on Base
 
 Base swap quotes and transaction requests use LI.FI's public quote API. Token
 approval and swap signing always occur in the connected wallet.
+
+## Wallet data sources
+
+The built-in Base wallet uses LI.FI, not Farcaster's wallet positions API:
+
+- `GET https://li.quest/v1/wallets/{address}/balances?extended=true` discovers
+  token contracts and estimated USD prices. Only Base entries are displayed.
+- `GET https://li.quest/v1/token?chain=8453&token={contract}` resolves tokens
+  entered manually in Send or Trade. Unsupported tokens produce an error, not
+  a fabricated zero balance. LI.FI native ETH is the zero-address marker.
+- LI.FI indexed quantities are **not** used as spendable balances. Base RPC
+  reads verify native balances, ERC-20 `balanceOf`, and token decimals.
+- Portfolio, the ETH header, Send, and Trade use the same React Query balance
+  cache keyed by chain ID, wallet address, and contract. Fresh preflight checks
+  publish into this cache. Confirmed sends/swaps invalidate the wallet cache.
+- Balance reads refresh every 30 seconds while observed; discovery every 60
+  seconds. The portfolio checks 20 token rows at a time, with Show more.
+- USD values are live quantities multiplied by LI.FI's estimated token prices.
+  Unknown prices and failed balance reads show unavailable/`—`, not zero.
+
+No LI.FI API key or new build variable is added by this integration. Requests
+use the public REST API directly, as swaps already did; rate limits or service
+changes can affect availability. Farcaster authentication is not required by
+the wallet-data hooks, although the surrounding client still uses Farcaster
+for social features and login. LI.FI receives the public wallet address and
+requested contracts; chain RPC providers receive balance queries. No Farcaster
+auth headers, cookies, private keys, or seeds are sent to LI.FI.
+
+LI.FI discovery can be incomplete or delayed. Its verification labels are not
+a security guarantee. Unverified tokens are hidden by default and can be shown
+explicitly. Known zero balances are omitted from portfolio rows; RPC failures
+remain visible as unavailable. Contract entry in Send/Trade supports tokens
+recognized by LI.FI but does not persist a custom token list yet.
+
+Live checks cannot guarantee a later transaction succeeds: funds can move,
+fees can change, and tokens can impose restrictions. Signing remains external.
+Swap approvals are exact-amount; approval receipts must succeed before a swap.
+If a refreshed quote worsens the reviewed minimum or changes spender, the user
+must obtain and review a new quote. Submission is distinguished from receipt
+confirmation. This patch does not add multichain transfers or portfolio history.
 
 ## Troubleshooting
 

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
@@ -6,58 +6,51 @@ import {
   CheckIcon,
   CopyIcon,
 } from 'lucide-react';
-import { FormEvent, ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { QRCode } from 'react-qrcode-logo';
-import { formatUnits, isAddress, parseEther } from 'viem';
+import { formatUnits } from 'viem';
 import { base } from 'viem/chains';
-import { useBalance, useConnect, useDisconnect } from 'wagmi';
+import { useConnect, useDisconnect } from 'wagmi';
 
 import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
 import { Image } from '~/components/images/Image';
 import { ExternalWalletPortfolio } from '~/components/rightSidebar/ExternalWalletPortfolio';
+import { ExternalWalletSend } from '~/components/rightSidebar/ExternalWalletSend';
 import { ExternalWalletSwap } from '~/components/rightSidebar/ExternalWalletSwap';
 import { useWallet } from '~/contexts/WalletProvider';
+import { useLifiAsset } from '~/hooks/useLifiWallet';
 import { truncateAddress } from '~/utils/ethereumUtils';
-import { sendBaseNativeToken } from '~/utils/sendBaseNativeToken';
+import { LIFI_NATIVE_ADDRESS } from '~/utils/lifiWallet';
 
 type WalletView = 'overview' | 'receive' | 'send' | 'trade';
 
 function ExternalWalletPanel() {
-  const {
-    address,
-    provider,
-    clearPreferredWallet,
-    connectors,
-    setPreferredWallet,
-  } = useWallet();
+  const { address, clearPreferredWallet, connectors, setPreferredWallet } =
+    useWallet();
   const { connectAsync } = useConnect();
   const { disconnect } = useDisconnect();
-  const { data: balance, isLoading: isBalanceLoading } = useBalance({
-    address,
-    chainId: base.id,
-  });
+  const {
+    data: balance,
+    isLoading: isBalanceLoading,
+    isError: balanceError,
+  } = useLifiAsset(address, LIFI_NATIVE_ADDRESS);
   const [view, setView] = useState<WalletView>('overview');
   const [copied, setCopied] = useState(false);
-  const [recipient, setRecipient] = useState('');
-  const [amount, setAmount] = useState('');
-  const [isSending, setIsSending] = useState(false);
-  const [sendError, setSendError] = useState<string>();
-  const [transactionHash, setTransactionHash] = useState<string>();
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string>();
 
   const formattedBalance = useMemo(() => {
-    if (!balance) {
+    if (!balance || balanceError) {
       return isBalanceLoading ? 'Loading…' : '—';
     }
 
     const value = Number(
-      formatUnits(balance.value, balance.decimals),
+      formatUnits(balance.balance, balance.decimals),
     ).toLocaleString(undefined, {
       maximumFractionDigits: 6,
     });
     return `${value} ${balance.symbol}`;
-  }, [balance, isBalanceLoading]);
+  }, [balance, isBalanceLoading, balanceError]);
 
   const browserWallets = connectors.filter(
     (connector) => connector.type === 'injected',
@@ -158,53 +151,6 @@ function ExternalWalletPanel() {
     clearPreferredWallet();
   };
 
-  const handleSend = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setSendError(undefined);
-    setTransactionHash(undefined);
-
-    if (!provider) {
-      setSendError('Wallet provider is unavailable. Reconnect and try again.');
-      return;
-    }
-
-    if (!isAddress(recipient)) {
-      setSendError('Enter a valid EVM address.');
-      return;
-    }
-
-    let value: bigint;
-    try {
-      value = parseEther(amount);
-    } catch {
-      setSendError('Enter a valid amount.');
-      return;
-    }
-
-    if (value <= 0n) {
-      setSendError('Amount must be greater than zero.');
-      return;
-    }
-
-    setIsSending(true);
-    try {
-      const hash = await sendBaseNativeToken({
-        provider,
-        address,
-        recipient,
-        value,
-      });
-      setTransactionHash(String(hash));
-      setAmount('');
-    } catch (error) {
-      setSendError(
-        error instanceof Error ? error.message : 'Transaction was not sent.',
-      );
-    } finally {
-      setIsSending(false);
-    }
-  };
-
   return (
     <div
       className="flex h-full flex-col overflow-y-auto border-t p-4 bg-app border-default"
@@ -291,50 +237,10 @@ function ExternalWalletPanel() {
 
       {view === 'send' && (
         <WalletSubscreen
-          title="Send ETH on Base"
+          title="Send on Base"
           onBack={() => setView('overview')}
         >
-          <form className="flex flex-col gap-4 pt-4" onSubmit={handleSend}>
-            <div className="text-sm text-muted">
-              Sends use Base. If your wallet is on another network, you will be
-              asked to switch before reviewing the transaction.
-            </div>
-            <label className="flex flex-col gap-2 text-sm text-default">
-              Recipient
-              <input
-                className="rounded-xl border px-3 py-2 bg-app border-default"
-                placeholder="0x…"
-                value={recipient}
-                onChange={(event) => setRecipient(event.target.value.trim())}
-              />
-            </label>
-            <label className="flex flex-col gap-2 text-sm text-default">
-              Amount ({base.nativeCurrency.symbol})
-              <input
-                className="rounded-xl border px-3 py-2 bg-app border-default"
-                inputMode="decimal"
-                placeholder="0.0"
-                value={amount}
-                onChange={(event) => setAmount(event.target.value)}
-              />
-            </label>
-            {sendError && (
-              <div className="rounded-xl bg-red-50 p-3 text-sm text-red-600">
-                {sendError}
-              </div>
-            )}
-            {transactionHash && (
-              <div className="rounded-xl bg-green-50 p-3 text-sm text-green-700">
-                <div>Transaction submitted</div>
-                <div className="mt-1 break-all">
-                  {truncateAddress(transactionHash, 8)}
-                </div>
-              </div>
-            )}
-            <DefaultButton type="submit" isLoading={isSending}>
-              Review in wallet
-            </DefaultButton>
-          </form>
+          <ExternalWalletSend key={address.toLowerCase()} address={address} />
         </WalletSubscreen>
       )}
 
@@ -343,7 +249,7 @@ function ExternalWalletPanel() {
           title="Trade on Base"
           onBack={() => setView('overview')}
         >
-          <ExternalWalletSwap />
+          <ExternalWalletSwap key={address.toLowerCase()} />
         </WalletSubscreen>
       )}
     </div>

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
@@ -1,0 +1,383 @@
+import {
+  ArrowDownToLineIcon,
+  ArrowLeftIcon,
+  ArrowLeftRightIcon,
+  ArrowUpFromLineIcon,
+  CheckIcon,
+  CopyIcon,
+} from 'lucide-react';
+import { FormEvent, ReactNode, useMemo, useState } from 'react';
+import { QRCode } from 'react-qrcode-logo';
+import { formatUnits, isAddress, parseEther, toHex } from 'viem';
+import { base } from 'viem/chains';
+import { useAccount, useBalance, useConnect, useDisconnect } from 'wagmi';
+
+import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
+import { Image } from '~/components/images/Image';
+import { ExternalWalletSwap } from '~/components/rightSidebar/ExternalWalletSwap';
+import { useWallet } from '~/contexts/WalletProvider';
+import { truncateAddress } from '~/utils/ethereumUtils';
+
+type WalletView = 'overview' | 'receive' | 'send' | 'trade';
+
+function ExternalWalletPanel() {
+  const {
+    address,
+    provider,
+    clearPreferredWallet,
+    connectors,
+    setPreferredWallet,
+  } = useWallet();
+  const { chain } = useAccount();
+  const { connectAsync } = useConnect();
+  const { disconnect } = useDisconnect();
+  const { data: balance, isLoading: isBalanceLoading } = useBalance({
+    address,
+  });
+  const [view, setView] = useState<WalletView>('overview');
+  const [copied, setCopied] = useState(false);
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string>();
+  const [transactionHash, setTransactionHash] = useState<string>();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string>();
+
+  const formattedBalance = useMemo(() => {
+    if (!balance) {
+      return isBalanceLoading ? 'Loading…' : '—';
+    }
+
+    const value = Number(
+      formatUnits(balance.value, balance.decimals),
+    ).toLocaleString(undefined, {
+      maximumFractionDigits: 6,
+    });
+    return `${value} ${balance.symbol}`;
+  }, [balance, isBalanceLoading]);
+
+  const browserWallets = connectors.filter(
+    (connector) => connector.type === 'injected',
+  );
+
+  if (!address) {
+    const connectWallet = async (connectorId: string) => {
+      const selectedConnector = connectors.find(
+        (connector) => connector.id === connectorId,
+      );
+
+      if (!selectedConnector) {
+        setConnectError(
+          connectorId === 'walletConnect'
+            ? 'WalletConnect is not configured. Add a Reown project ID and reload.'
+            : 'That browser wallet is no longer available. Reload and try again.',
+        );
+        return;
+      }
+
+      setConnectError(undefined);
+      setIsConnecting(true);
+      try {
+        await connectAsync({
+          connector: selectedConnector,
+          chainId: base.id,
+        });
+        setPreferredWallet(selectedConnector.id);
+      } catch (error) {
+        setConnectError(
+          error instanceof Error ? error.message : 'Wallet connection failed.',
+        );
+      } finally {
+        setIsConnecting(false);
+      }
+    };
+
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center border-t p-6 text-center bg-app border-default"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex size-14 items-center justify-center rounded-2xl bg-elevated-nohover">
+          <ArrowDownToLineIcon className="size-7 text-default" />
+        </div>
+        <div className="mt-4 text-xl font-semibold text-default">
+          Connect a wallet
+        </div>
+        <div className="mt-2 max-w-72 text-sm text-muted">
+          Connect once to use the same wallet here and in miniapps.
+        </div>
+        {connectError && (
+          <div className="mt-4 w-full rounded-xl bg-red-50 p-3 text-sm text-red-600">
+            {connectError}
+          </div>
+        )}
+        <div className="mt-6 flex w-full flex-col gap-2">
+          {browserWallets.map((connector) => (
+            <DefaultButton
+              key={connector.uid}
+              className="w-full"
+              variant="secondary"
+              isLoading={isConnecting}
+              onClick={() => void connectWallet(connector.id)}
+            >
+              <span className="flex items-center justify-center gap-2">
+                {connector.icon && (
+                  <Image
+                    src={connector.icon}
+                    alt=""
+                    className="size-5 rounded"
+                  />
+                )}
+                {connector.name}
+              </span>
+            </DefaultButton>
+          ))}
+          <DefaultButton
+            className="w-full"
+            isLoading={isConnecting}
+            onClick={() => void connectWallet('walletConnect')}
+          >
+            Connect with WalletConnect
+          </DefaultButton>
+        </div>
+      </div>
+    );
+  }
+
+  const copyAddress = async () => {
+    await navigator.clipboard.writeText(address);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  const handleDisconnect = () => {
+    disconnect();
+    clearPreferredWallet();
+  };
+
+  const handleSend = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSendError(undefined);
+    setTransactionHash(undefined);
+
+    if (!provider) {
+      setSendError('Wallet provider is unavailable. Reconnect and try again.');
+      return;
+    }
+
+    if (!isAddress(recipient)) {
+      setSendError('Enter a valid EVM address.');
+      return;
+    }
+
+    let value: bigint;
+    try {
+      value = parseEther(amount);
+    } catch {
+      setSendError('Enter a valid amount.');
+      return;
+    }
+
+    if (value <= 0n) {
+      setSendError('Amount must be greater than zero.');
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      const hash = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: address,
+            to: recipient,
+            value: toHex(value),
+          },
+        ],
+      });
+      setTransactionHash(String(hash));
+      setAmount('');
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : 'Transaction was not sent.',
+      );
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex h-full flex-col overflow-y-auto border-t p-4 bg-app border-default"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {view === 'overview' && (
+        <>
+          <div className="rounded-2xl p-4 bg-elevated-nohover">
+            <div className="text-sm text-muted">{chain?.name ?? 'Wallet'}</div>
+            <div className="mt-1 text-3xl font-semibold text-default">
+              {formattedBalance}
+            </div>
+            <button
+              type="button"
+              className="mt-3 flex items-center gap-2 text-sm text-muted hover:text-default"
+              onClick={copyAddress}
+            >
+              <span>{truncateAddress(address, 6)}</span>
+              {copied ? (
+                <CheckIcon className="size-4" />
+              ) : (
+                <CopyIcon className="size-4" />
+              )}
+            </button>
+          </div>
+
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <WalletAction
+              label="Receive"
+              icon={<ArrowDownToLineIcon className="size-5" />}
+              onClick={() => setView('receive')}
+            />
+            <WalletAction
+              label="Send"
+              icon={<ArrowUpFromLineIcon className="size-5" />}
+              onClick={() => setView('send')}
+            />
+            <WalletAction
+              label="Trade"
+              icon={<ArrowLeftRightIcon className="size-5" />}
+              onClick={() => setView('trade')}
+            />
+          </div>
+
+          <div className="mt-auto pt-6">
+            <DefaultButton
+              className="w-full"
+              variant="danger"
+              onClick={handleDisconnect}
+            >
+              Disconnect
+            </DefaultButton>
+          </div>
+        </>
+      )}
+
+      {view === 'receive' && (
+        <WalletSubscreen title="Receive" onBack={() => setView('overview')}>
+          <div className="flex flex-col items-center gap-4 py-4">
+            <div className="overflow-hidden rounded-2xl bg-white p-2">
+              <QRCode value={address} size={180} quietZone={8} />
+            </div>
+            <div className="break-all text-center text-sm text-muted">
+              {address}
+            </div>
+            <DefaultButton className="w-full" onClick={copyAddress}>
+              {copied ? 'Copied' : 'Copy address'}
+            </DefaultButton>
+          </div>
+        </WalletSubscreen>
+      )}
+
+      {view === 'send' && (
+        <WalletSubscreen title="Send" onBack={() => setView('overview')}>
+          <form className="flex flex-col gap-4 pt-4" onSubmit={handleSend}>
+            <label className="flex flex-col gap-2 text-sm text-default">
+              Recipient
+              <input
+                className="rounded-xl border px-3 py-2 bg-app border-default"
+                placeholder="0x…"
+                value={recipient}
+                onChange={(event) => setRecipient(event.target.value.trim())}
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-default">
+              Amount ({balance?.symbol ?? 'ETH'})
+              <input
+                className="rounded-xl border px-3 py-2 bg-app border-default"
+                inputMode="decimal"
+                placeholder="0.0"
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
+              />
+            </label>
+            {sendError && (
+              <div className="rounded-xl bg-red-50 p-3 text-sm text-red-600">
+                {sendError}
+              </div>
+            )}
+            {transactionHash && (
+              <div className="rounded-xl bg-green-50 p-3 text-sm text-green-700">
+                <div>Transaction submitted</div>
+                <div className="mt-1 break-all">
+                  {truncateAddress(transactionHash, 8)}
+                </div>
+              </div>
+            )}
+            <DefaultButton type="submit" isLoading={isSending}>
+              Review in wallet
+            </DefaultButton>
+          </form>
+        </WalletSubscreen>
+      )}
+
+      {view === 'trade' && (
+        <WalletSubscreen
+          title="Trade on Base"
+          onBack={() => setView('overview')}
+        >
+          <ExternalWalletSwap />
+        </WalletSubscreen>
+      )}
+    </div>
+  );
+}
+
+function WalletAction({
+  label,
+  icon,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex flex-col items-center gap-2 rounded-xl p-3 text-sm font-semibold bg-elevated-nohover text-default hover:bg-overlay-light"
+      onClick={onClick}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function WalletSubscreen({
+  title,
+  onBack,
+  children,
+}: {
+  title: string;
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="flex size-8 items-center justify-center rounded-full hover:bg-overlay-light"
+          onClick={onBack}
+        >
+          <ArrowLeftIcon className="size-5" />
+        </button>
+        <div className="font-semibold text-default">{title}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export { ExternalWalletPanel };

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
@@ -14,6 +14,7 @@ import { useBalance, useConnect, useDisconnect } from 'wagmi';
 
 import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
 import { Image } from '~/components/images/Image';
+import { ExternalWalletPortfolio } from '~/components/rightSidebar/ExternalWalletPortfolio';
 import { ExternalWalletSwap } from '~/components/rightSidebar/ExternalWalletSwap';
 import { useWallet } from '~/contexts/WalletProvider';
 import { truncateAddress } from '~/utils/ethereumUtils';
@@ -247,6 +248,11 @@ function ExternalWalletPanel() {
               onClick={() => setView('trade')}
             />
           </div>
+
+          <ExternalWalletPortfolio
+            key={address.toLowerCase()}
+            address={address}
+          />
 
           <div className="mt-auto pt-6">
             <DefaultButton

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPanel.tsx
@@ -8,15 +8,16 @@ import {
 } from 'lucide-react';
 import { FormEvent, ReactNode, useMemo, useState } from 'react';
 import { QRCode } from 'react-qrcode-logo';
-import { formatUnits, isAddress, parseEther, toHex } from 'viem';
+import { formatUnits, isAddress, parseEther } from 'viem';
 import { base } from 'viem/chains';
-import { useAccount, useBalance, useConnect, useDisconnect } from 'wagmi';
+import { useBalance, useConnect, useDisconnect } from 'wagmi';
 
 import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
 import { Image } from '~/components/images/Image';
 import { ExternalWalletSwap } from '~/components/rightSidebar/ExternalWalletSwap';
 import { useWallet } from '~/contexts/WalletProvider';
 import { truncateAddress } from '~/utils/ethereumUtils';
+import { sendBaseNativeToken } from '~/utils/sendBaseNativeToken';
 
 type WalletView = 'overview' | 'receive' | 'send' | 'trade';
 
@@ -28,11 +29,11 @@ function ExternalWalletPanel() {
     connectors,
     setPreferredWallet,
   } = useWallet();
-  const { chain } = useAccount();
   const { connectAsync } = useConnect();
   const { disconnect } = useDisconnect();
   const { data: balance, isLoading: isBalanceLoading } = useBalance({
     address,
+    chainId: base.id,
   });
   const [view, setView] = useState<WalletView>('overview');
   const [copied, setCopied] = useState(false);
@@ -186,15 +187,11 @@ function ExternalWalletPanel() {
 
     setIsSending(true);
     try {
-      const hash = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: address,
-            to: recipient,
-            value: toHex(value),
-          },
-        ],
+      const hash = await sendBaseNativeToken({
+        provider,
+        address,
+        recipient,
+        value,
       });
       setTransactionHash(String(hash));
       setAmount('');
@@ -215,7 +212,7 @@ function ExternalWalletPanel() {
       {view === 'overview' && (
         <>
           <div className="rounded-2xl p-4 bg-elevated-nohover">
-            <div className="text-sm text-muted">{chain?.name ?? 'Wallet'}</div>
+            <div className="text-sm text-muted">{base.name}</div>
             <div className="mt-1 text-3xl font-semibold text-default">
               {formattedBalance}
             </div>
@@ -264,8 +261,15 @@ function ExternalWalletPanel() {
       )}
 
       {view === 'receive' && (
-        <WalletSubscreen title="Receive" onBack={() => setView('overview')}>
+        <WalletSubscreen
+          title="Receive on Base"
+          onBack={() => setView('overview')}
+        >
           <div className="flex flex-col items-center gap-4 py-4">
+            <div className="text-center text-sm text-muted">
+              Select Base as the sending network. This QR code contains only
+              your address; it does not select the network for the sender.
+            </div>
             <div className="overflow-hidden rounded-2xl bg-white p-2">
               <QRCode value={address} size={180} quietZone={8} />
             </div>
@@ -280,8 +284,15 @@ function ExternalWalletPanel() {
       )}
 
       {view === 'send' && (
-        <WalletSubscreen title="Send" onBack={() => setView('overview')}>
+        <WalletSubscreen
+          title="Send ETH on Base"
+          onBack={() => setView('overview')}
+        >
           <form className="flex flex-col gap-4 pt-4" onSubmit={handleSend}>
+            <div className="text-sm text-muted">
+              Sends use Base. If your wallet is on another network, you will be
+              asked to switch before reviewing the transaction.
+            </div>
             <label className="flex flex-col gap-2 text-sm text-default">
               Recipient
               <input
@@ -292,7 +303,7 @@ function ExternalWalletPanel() {
               />
             </label>
             <label className="flex flex-col gap-2 text-sm text-default">
-              Amount ({balance?.symbol ?? 'ETH'})
+              Amount ({base.nativeCurrency.symbol})
               <input
                 className="rounded-xl border px-3 py-2 bg-app border-default"
                 inputMode="decimal"

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPortfolio.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPortfolio.tsx
@@ -1,0 +1,169 @@
+import { useWalletPositionsQuery } from 'farcaster-client-hooks';
+import React, { useState } from 'react';
+import { Address, isAddress } from 'viem';
+
+import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
+import { useIsSignedIn } from '~/hooks/data/useIsSignedIn';
+import {
+  formatPortfolioBalance,
+  formatPortfolioUsd,
+  isBasePortfolioToken,
+  isPortfolioPositionHidden,
+  selectBasePortfolioPositions,
+} from '~/utils/baseWalletPortfolio';
+import { truncateAddress } from '~/utils/ethereumUtils';
+
+const PAGE_SIZE = 20;
+
+export function ExternalWalletPortfolio({ address }: { address: Address }) {
+  const isSignedIn = useIsSignedIn();
+  const [showHidden, setShowHidden] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const { data, isPending, isError, isFetching, refetch } =
+    useWalletPositionsQuery({
+      params: { address: address.toLowerCase() },
+      enabled: isSignedIn,
+      keepPreviousData: false,
+      staleTime: 30_000,
+      refetchInterval: 60_000,
+    });
+  const basePositions = (data?.positions ?? []).filter(isBasePortfolioToken);
+  const hiddenCount = basePositions.filter(isPortfolioPositionHidden).length;
+  const positions = selectBasePortfolioPositions(basePositions, showHidden);
+
+  return (
+    <section className="mt-6" aria-label="Base token portfolio">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="font-semibold text-default">Tokens on Base</h3>
+        <DefaultButton
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={!isSignedIn || isFetching}
+          onClick={() => void refetch()}
+        >
+          {isFetching ? 'Refreshing…' : 'Refresh tokens'}
+        </DefaultButton>
+      </div>
+      <p className="mt-2 text-xs text-muted">
+        Balances and USD estimates from Farcaster may be delayed. Missing prices
+        are shown as —, not zero. Native ETH is shown separately above.
+      </p>
+
+      {!isSignedIn ? (
+        <p className="mt-3 text-sm text-muted">
+          Sign in to Farcaster to load token holdings.
+        </p>
+      ) : (
+        <>
+          {isPending && !isError && (
+            <p className="mt-3 text-sm text-muted" role="status">
+              Loading Base tokens…
+            </p>
+          )}
+          {isError && (
+            <p className="mt-3 text-sm text-muted" role="alert">
+              {data
+                ? 'Could not refresh tokens. Displayed balances may be out of date.'
+                : 'Could not load Base tokens. Try refreshing.'}
+            </p>
+          )}
+          {data && (
+            <>
+              {hiddenCount > 0 && (
+                <label className="mt-3 flex items-center gap-2 text-sm text-muted">
+                  <input
+                    type="checkbox"
+                    checked={showHidden}
+                    onChange={(event) => {
+                      setShowHidden(event.target.checked);
+                      setVisibleCount(PAGE_SIZE);
+                    }}
+                  />
+                  Show hidden tokens ({hiddenCount})
+                </label>
+              )}
+              {showHidden && hiddenCount > 0 && (
+                <p className="mt-2 text-xs text-muted">
+                  Hidden flags come from the source or wallet preferences, not a
+                  safety guarantee. Token names are untrusted; ignore claim
+                  links.
+                </p>
+              )}
+              {positions.length === 0 ? (
+                <p className="mt-3 text-sm text-muted">
+                  {hiddenCount > 0
+                    ? 'All returned Base tokens are hidden.'
+                    : 'No Base token holdings to show. Native ETH is shown above.'}
+                </p>
+              ) : (
+                <ul className="divide-default mt-3 divide-y">
+                  {positions.slice(0, visibleCount).map((position) => {
+                    const balance = formatPortfolioBalance(position);
+                    const contract = position.address;
+                    return (
+                      <li
+                        key={`base:${contract ?? position.id}:${position.id}`}
+                        className="flex items-start justify-between gap-3 py-3"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div
+                            className="truncate text-sm font-semibold text-default"
+                            title={
+                              position.symbol ??
+                              position.name ??
+                              'Unknown token'
+                            }
+                          >
+                            {position.symbol ??
+                              position.name ??
+                              'Unknown token'}
+                          </div>
+                          <div
+                            className="break-all text-xs text-muted"
+                            title={balance.exact}
+                          >
+                            {balance.display}
+                          </div>
+                          {contract && isAddress(contract) ? (
+                            <a
+                              className="text-accent-primary text-xs hover:underline"
+                              href={`https://basescan.org/token/${contract}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={`View contract ${contract} on BaseScan`}
+                            >
+                              {truncateAddress(contract, 4)}
+                            </a>
+                          ) : null}
+                          {isPortfolioPositionHidden(position) && (
+                            <span className="ml-2 text-xs text-muted">
+                              Hidden
+                            </span>
+                          )}
+                        </div>
+                        <div className="shrink-0 text-sm text-default">
+                          {formatPortfolioUsd(position.value)}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+              {positions.length > visibleCount && (
+                <DefaultButton
+                  type="button"
+                  variant="secondary"
+                  className="mt-3 w-full"
+                  onClick={() => setVisibleCount((count) => count + PAGE_SIZE)}
+                >
+                  Show more tokens ({positions.length - visibleCount} remaining)
+                </DefaultButton>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPortfolio.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletPortfolio.tsx
@@ -1,169 +1,233 @@
-import { useWalletPositionsQuery } from 'farcaster-client-hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { LoaderCircleIcon, RefreshCwIcon } from 'lucide-react';
 import React, { useState } from 'react';
-import { Address, isAddress } from 'viem';
+import { Address, zeroAddress } from 'viem';
 
 import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
-import { useIsSignedIn } from '~/hooks/data/useIsSignedIn';
 import {
-  formatPortfolioBalance,
-  formatPortfolioUsd,
-  isBasePortfolioToken,
-  isPortfolioPositionHidden,
-  selectBasePortfolioPositions,
-} from '~/utils/baseWalletPortfolio';
+  refreshLifiWallet,
+  useLifiAssets,
+  useLifiWalletTokens,
+} from '~/hooks/useLifiWallet';
+import { formatPortfolioUsd } from '~/utils/baseWalletPortfolio';
 import { truncateAddress } from '~/utils/ethereumUtils';
+import { formatLifiBalance, lifiAssetUsd } from '~/utils/lifiWallet';
 
 const PAGE_SIZE = 20;
 
 export function ExternalWalletPortfolio({ address }: { address: Address }) {
-  const isSignedIn = useIsSignedIn();
-  const [showHidden, setShowHidden] = useState(false);
+  const queryClient = useQueryClient();
+  const [showUnverified, setShowUnverified] = useState(false);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  const { data, isPending, isError, isFetching, refetch } =
-    useWalletPositionsQuery({
-      params: { address: address.toLowerCase() },
-      enabled: isSignedIn,
-      keepPreviousData: false,
-      staleTime: 30_000,
-      refetchInterval: 60_000,
-    });
-  const basePositions = (data?.positions ?? []).filter(isBasePortfolioToken);
-  const hiddenCount = basePositions.filter(isPortfolioPositionHidden).length;
-  const positions = selectBasePortfolioPositions(basePositions, showHidden);
+  const { data, isPending, isError, isFetching } = useLifiWalletTokens(address);
+  const allTokens = (data?.tokens ?? []).filter(
+    (token) => token.address !== zeroAddress,
+  );
+  const unverifiedCount = allTokens.filter(
+    (token) => token.verificationStatus !== 'verified',
+  ).length;
+  const tokens = allTokens.filter(
+    (token) => showUnverified || token.verificationStatus === 'verified',
+  );
+  const visible = tokens.slice(0, visibleCount);
+  const balances = useLifiAssets(
+    address,
+    visible.map((token) => token.address),
+  );
+  const initialLoading = isPending && !data && !isError;
+  const loadingBalances = visible.some(
+    (_, index) => !balances[index]?.data && !balances[index]?.isError,
+  );
+  const refreshing =
+    initialLoading ||
+    loadingBalances ||
+    isFetching ||
+    balances.some((balance) => balance.isFetching);
+  const allZero =
+    visible.length > 0 &&
+    balances.length === visible.length &&
+    balances.every(
+      (balance) => !balance.isError && balance.data?.balance === 0n,
+    );
 
   return (
-    <section className="mt-6" aria-label="Base token portfolio">
-      <div className="flex items-center justify-between gap-2">
-        <h3 className="font-semibold text-default">Tokens on Base</h3>
+    <section
+      className="mt-6 rounded-2xl border p-4 border-default"
+      aria-label="Base token portfolio"
+      aria-busy={Boolean(refreshing)}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-default">
+            Tokens on Base
+          </h3>
+          <p className="mt-1 text-xs text-muted">
+            Token balances · Estimated USD value
+          </p>
+        </div>
         <DefaultButton
           type="button"
           variant="secondary"
           size="sm"
-          disabled={!isSignedIn || isFetching}
-          onClick={() => void refetch()}
+          className="inline-flex shrink-0 items-center gap-2"
+          disabled={refreshing}
+          onClick={() => void refreshLifiWallet(queryClient, address)}
         >
-          {isFetching ? 'Refreshing…' : 'Refresh tokens'}
+          <RefreshCwIcon
+            aria-hidden="true"
+            className={`size-3.5 ${refreshing ? 'animate-spin motion-reduce:animate-none' : ''}`}
+          />
+          {refreshing ? 'Refreshing…' : 'Refresh tokens'}
         </DefaultButton>
       </div>
-      <p className="mt-2 text-xs text-muted">
-        Balances and USD estimates from Farcaster may be delayed. Missing prices
-        are shown as —, not zero. Native ETH is shown separately above.
-      </p>
-
-      {!isSignedIn ? (
-        <p className="mt-3 text-sm text-muted">
-          Sign in to Farcaster to load token holdings.
+      {initialLoading && (
+        <div
+          className="mt-4 flex min-h-36 flex-col items-center justify-center gap-3 rounded-xl p-6 text-sm text-muted bg-elevated-nohover"
+          role="status"
+        >
+          <LoaderCircleIcon
+            aria-hidden="true"
+            className="text-accent-primary size-6 animate-spin motion-reduce:animate-none"
+          />
+          <span>Loading Base tokens…</span>
+        </div>
+      )}
+      {loadingBalances && !initialLoading && (
+        <div
+          role="status"
+          className="mt-4 flex items-center gap-2 text-xs text-muted"
+        >
+          <LoaderCircleIcon
+            aria-hidden="true"
+            className="size-4 animate-spin motion-reduce:animate-none"
+          />
+          Checking token balances on Base…
+        </div>
+      )}
+      {refreshing && !initialLoading && !loadingBalances && (
+        <span role="status" className="sr-only">
+          Updating token balances…
+        </span>
+      )}
+      {isError && (
+        <p
+          className="mt-4 rounded-xl p-3 text-sm leading-relaxed text-muted bg-elevated-nohover"
+          role="alert"
+        >
+          Could not load tokens from LI.FI. Try refreshing.{' '}
+          {data ? 'The token list may be out of date.' : ''}
         </p>
-      ) : (
+      )}
+      {data && (
         <>
-          {isPending && !isError && (
-            <p className="mt-3 text-sm text-muted" role="status">
-              Loading Base tokens…
+          {(data.possiblyLimited || data.skipped > 0) && (
+            <p className="mt-2 text-xs text-muted">
+              LI.FI returned a partial token list. Some holdings may be missing.
             </p>
           )}
-          {isError && (
-            <p className="mt-3 text-sm text-muted" role="alert">
-              {data
-                ? 'Could not refresh tokens. Displayed balances may be out of date.'
-                : 'Could not load Base tokens. Try refreshing.'}
+          {unverifiedCount > 0 && (
+            <label className="mt-4 flex cursor-pointer items-center gap-2 rounded-lg py-1 text-xs text-muted">
+              <input
+                type="checkbox"
+                checked={showUnverified}
+                onChange={(event) => {
+                  setShowUnverified(event.target.checked);
+                  setVisibleCount(PAGE_SIZE);
+                }}
+              />
+              Show unverified tokens ({unverifiedCount})
+            </label>
+          )}
+          {showUnverified && (
+            <p className="mt-2 text-xs text-muted">
+              Unverified tokens may include spam. LI.FI verification is not a
+              safety guarantee. Check contracts; ignore claim links.
             </p>
           )}
-          {data && (
-            <>
-              {hiddenCount > 0 && (
-                <label className="mt-3 flex items-center gap-2 text-sm text-muted">
-                  <input
-                    type="checkbox"
-                    checked={showHidden}
-                    onChange={(event) => {
-                      setShowHidden(event.target.checked);
-                      setVisibleCount(PAGE_SIZE);
-                    }}
-                  />
-                  Show hidden tokens ({hiddenCount})
-                </label>
-              )}
-              {showHidden && hiddenCount > 0 && (
-                <p className="mt-2 text-xs text-muted">
-                  Hidden flags come from the source or wallet preferences, not a
-                  safety guarantee. Token names are untrusted; ignore claim
-                  links.
-                </p>
-              )}
-              {positions.length === 0 ? (
-                <p className="mt-3 text-sm text-muted">
-                  {hiddenCount > 0
-                    ? 'All returned Base tokens are hidden.'
-                    : 'No Base token holdings to show. Native ETH is shown above.'}
-                </p>
-              ) : (
-                <ul className="divide-default mt-3 divide-y">
-                  {positions.slice(0, visibleCount).map((position) => {
-                    const balance = formatPortfolioBalance(position);
-                    const contract = position.address;
-                    return (
-                      <li
-                        key={`base:${contract ?? position.id}:${position.id}`}
-                        className="flex items-start justify-between gap-3 py-3"
+          {(tokens.length === 0 || allZero) && (
+            <p className="mt-4 rounded-xl p-4 text-sm leading-relaxed text-muted bg-elevated-nohover">
+              No non-zero Base token balances in this selection. Native ETH is
+              shown above.
+            </p>
+          )}
+          <ul className="divide-default mt-4 divide-y">
+            {visible.map((token, index) => {
+              const balance = balances[index];
+              if (!balance?.isError && balance?.data?.balance === 0n) {
+                return null;
+              }
+              const asset = balance?.isError ? undefined : balance?.data;
+              return (
+                <li key={token.address} className="flex items-start gap-3 py-4">
+                  <div
+                    aria-hidden="true"
+                    className="flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-muted bg-elevated-nohover"
+                  >
+                    {token.symbol.slice(0, 2).toUpperCase()}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div
+                      className="truncate text-sm font-semibold text-default"
+                      title={token.name}
+                    >
+                      {token.symbol}
+                    </div>
+                    <div className="mt-1 break-all text-xs tabular-nums text-muted">
+                      {asset
+                        ? formatLifiBalance(asset)
+                        : balance?.isError
+                          ? 'Balance unavailable'
+                          : 'Checking balance…'}
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <a
+                        className="text-accent-primary text-xs hover:underline"
+                        href={`https://basescan.org/token/${token.address}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`View contract ${token.address} on BaseScan`}
                       >
-                        <div className="min-w-0 flex-1">
-                          <div
-                            className="truncate text-sm font-semibold text-default"
-                            title={
-                              position.symbol ??
-                              position.name ??
-                              'Unknown token'
-                            }
-                          >
-                            {position.symbol ??
-                              position.name ??
-                              'Unknown token'}
-                          </div>
-                          <div
-                            className="break-all text-xs text-muted"
-                            title={balance.exact}
-                          >
-                            {balance.display}
-                          </div>
-                          {contract && isAddress(contract) ? (
-                            <a
-                              className="text-accent-primary text-xs hover:underline"
-                              href={`https://basescan.org/token/${contract}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              aria-label={`View contract ${contract} on BaseScan`}
-                            >
-                              {truncateAddress(contract, 4)}
-                            </a>
-                          ) : null}
-                          {isPortfolioPositionHidden(position) && (
-                            <span className="ml-2 text-xs text-muted">
-                              Hidden
-                            </span>
-                          )}
-                        </div>
-                        <div className="shrink-0 text-sm text-default">
-                          {formatPortfolioUsd(position.value)}
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-              {positions.length > visibleCount && (
-                <DefaultButton
-                  type="button"
-                  variant="secondary"
-                  className="mt-3 w-full"
-                  onClick={() => setVisibleCount((count) => count + PAGE_SIZE)}
-                >
-                  Show more tokens ({positions.length - visibleCount} remaining)
-                </DefaultButton>
-              )}
-            </>
+                        {truncateAddress(token.address, 4)}
+                      </a>
+                      {token.verificationStatus !== 'verified' && (
+                        <span className="rounded-full border px-1.5 py-0.5 text-xs text-muted border-default">
+                          Unverified
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="max-w-[45%] shrink-0 break-all text-right text-sm font-medium tabular-nums text-default">
+                    {formatPortfolioUsd(
+                      asset ? lifiAssetUsd(asset) : undefined,
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          {tokens.length > visibleCount && (
+            <DefaultButton
+              type="button"
+              variant="secondary"
+              className="mt-3 w-full"
+              onClick={() => setVisibleCount((count) => count + PAGE_SIZE)}
+            >
+              Show more tokens ({tokens.length - visibleCount} remaining)
+            </DefaultButton>
           )}
+          <p className="mt-4 text-xs leading-relaxed text-muted">
+            Missing a token? You can enter its Base contract in Send or Trade if
+            LI.FI recognizes it.
+          </p>
         </>
       )}
+      <details className="mt-4 border-t pt-3 text-xs leading-relaxed text-muted border-default">
+        <summary className="cursor-pointer">About these balances</summary>
+        <p className="mt-2">
+          Token discovery and estimated prices by LI.FI. Balances are checked on
+          Base and shared with Send and Trade. Native ETH is shown above.
+        </p>
+      </details>
     </section>
   );
 }

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSend.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSend.tsx
@@ -1,0 +1,384 @@
+import { useQueryClient } from '@tanstack/react-query';
+import React, { FormEvent, useEffect, useRef, useState } from 'react';
+import {
+  Address,
+  formatEther,
+  formatUnits,
+  Hash,
+  isAddress,
+  zeroAddress,
+} from 'viem';
+import { base } from 'viem/chains';
+import { useWaitForTransactionReceipt } from 'wagmi';
+
+import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
+import { useWallet } from '~/contexts/WalletProvider';
+import {
+  refreshLifiWallet,
+  useLifiAsset,
+  useLifiTransferReader,
+  useLifiWalletTokens,
+} from '~/hooks/useLifiWallet';
+import {
+  prepareBaseTransfer,
+  PreparedBaseTransfer,
+  submitBaseTransfer,
+} from '~/utils/baseWalletTransfer';
+import { truncateAddress } from '~/utils/ethereumUtils';
+
+export function ExternalWalletSend({ address }: { address: Address }) {
+  const { provider } = useWallet();
+  const reader = useLifiTransferReader();
+  const queryClient = useQueryClient();
+  const {
+    data,
+    isError: tokensError,
+    isPending: tokensPending,
+  } = useLifiWalletTokens(address);
+  const [showHidden, setShowHidden] = useState(false);
+  const [token, setToken] = useState('native');
+  const [customToken, setCustomToken] = useState('');
+  const selectedAddress =
+    token === 'native' ? zeroAddress : token === 'custom' ? customToken : token;
+  const tokenBalance = useLifiAsset(
+    address,
+    isAddress(selectedAddress) ? selectedAddress : undefined,
+  );
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [prepared, setPrepared] = useState<PreparedBaseTransfer>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [hash, setHash] = useState<Hash>();
+  const [replacementReason, setReplacementReason] = useState<string>();
+  const operation = useRef(0);
+  const locked = useRef(false);
+  const identity = useRef({ address, provider });
+  identity.current = { address, provider };
+
+  useEffect(() => {
+    operation.current += 1;
+    setPrepared(undefined);
+    return () => {
+      operation.current += 1;
+    };
+  }, [address, provider]);
+
+  const { data: receipt, isError: receiptError } = useWaitForTransactionReceipt(
+    {
+      hash,
+      chainId: base.id,
+      timeout: 60_000,
+      onReplaced: (replacement) => setReplacementReason(replacement.reason),
+    },
+  );
+  const balanceText = !isAddress(selectedAddress)
+    ? 'Enter a Base contract to load its balance.'
+    : tokenBalance.isError
+      ? 'Could not load balance on Base. Try refreshing.'
+      : tokenBalance.data
+        ? `Available on Base: ${formatUnits(tokenBalance.data.balance, tokenBalance.data.decimals)} ${tokenBalance.data.symbol}`
+        : 'Loading balance on Base…';
+  const receiptHash = receipt?.transactionHash;
+  useEffect(() => {
+    if (receiptHash) {
+      void refreshLifiWallet(queryClient, address);
+    }
+  }, [receiptHash, queryClient, address]);
+
+  const tokens = (data?.tokens ?? []).filter(
+    (position) =>
+      position.address !== zeroAddress &&
+      (showHidden || position.verificationStatus === 'verified'),
+  );
+  const edit = () => {
+    operation.current += 1;
+    setPrepared(undefined);
+    setError(undefined);
+  };
+
+  const review = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!reader || locked.current) {
+      return;
+    }
+    locked.current = true;
+    const version = ++operation.current;
+    setBusy(true);
+    setPrepared(undefined);
+    setError(undefined);
+    setHash(undefined);
+    setReplacementReason(undefined);
+    try {
+      if (!isAddress(selectedAddress)) {
+        throw new Error('Choose a valid token.');
+      }
+      const next = await prepareBaseTransfer(reader, {
+        address,
+        recipient,
+        amount,
+        tokenAddress:
+          selectedAddress === zeroAddress ? undefined : selectedAddress,
+      });
+      if (version === operation.current) {
+        setPrepared(next);
+      }
+    } catch (failure) {
+      if (version === operation.current) {
+        setError(
+          failure instanceof Error
+            ? failure.message
+            : 'Could not prepare the transfer.',
+        );
+      }
+    } finally {
+      locked.current = false;
+      setBusy(false);
+    }
+  };
+
+  const send = async () => {
+    if (!provider || !reader || !prepared || locked.current) {
+      return;
+    }
+    locked.current = true;
+    const version = operation.current;
+    const isCurrent = () =>
+      version === operation.current &&
+      identity.current.address === address &&
+      identity.current.provider === provider;
+    setBusy(true);
+    setError(undefined);
+    try {
+      const transactionHash = await submitBaseTransfer({
+        provider,
+        reader,
+        prepared,
+        isCurrent,
+      });
+      // A wallet may already have broadcast the transaction even if the view
+      // changed while its prompt was open. Never retry a submitted request.
+      if (identity.current.address === address) {
+        setHash(transactionHash);
+      }
+      setPrepared(undefined);
+    } catch (failure) {
+      if (isCurrent()) {
+        setError(
+          failure instanceof Error
+            ? failure.message
+            : 'Transfer was not submitted.',
+        );
+      }
+      setPrepared(undefined);
+    } finally {
+      locked.current = false;
+      setBusy(false);
+    }
+  };
+
+  const receiptStatus =
+    replacementReason === 'cancelled'
+      ? 'Transaction cancelled.'
+      : replacementReason === 'replaced'
+        ? 'Transaction replaced. Check BaseScan for the replacement details.'
+        : receipt
+          ? receipt.status === 'success'
+            ? 'Transaction confirmed on Base.'
+            : 'Transaction reverted on Base.'
+          : receiptError
+            ? 'Confirmation unavailable. Check BaseScan before sending again.'
+            : 'Transaction submitted. Waiting for confirmation…';
+
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <p className="text-sm text-muted">
+        Send ETH or an ERC-20 token on Base. Token transfers do not require an
+        allowance approval.
+      </p>
+      <form className="flex flex-col gap-4" onSubmit={review}>
+        <fieldset disabled={busy} className="flex min-w-0 flex-col gap-4">
+          <label className="flex flex-col gap-2 text-sm text-default">
+            Asset
+            <select
+              className="w-full rounded-xl border px-3 py-2 bg-app border-default"
+              value={token}
+              onChange={(event) => {
+                edit();
+                setToken(event.target.value);
+              }}
+            >
+              <option value="native">ETH — native asset</option>
+              {tokens.map((position) => (
+                <option key={position.address} value={position.address}>
+                  {position.symbol ?? position.name ?? 'Unknown token'} —{' '}
+                  {truncateAddress(position.address!, 4)}
+                </option>
+              ))}
+              <option value="custom">Enter token contract…</option>
+            </select>
+          </label>
+          {token === 'custom' && (
+            <label className="flex flex-col gap-2 text-sm text-default">
+              Base token contract
+              <input
+                className="rounded-xl border px-3 py-2 bg-app border-default"
+                placeholder="0x…"
+                value={customToken}
+                onChange={(event) => {
+                  edit();
+                  setCustomToken(event.target.value.trim());
+                }}
+              />
+            </label>
+          )}
+          <label className="flex items-center gap-2 text-sm text-muted">
+            <input
+              type="checkbox"
+              checked={showHidden}
+              onChange={(event) => {
+                edit();
+                setShowHidden(event.target.checked);
+                setToken('native');
+              }}
+            />
+            Include unverified tokens
+          </label>
+          {showHidden && (
+            <p className="text-xs text-muted">
+              Unverified tokens may include spam. Verify the contract; token
+              names are not a safety guarantee.
+            </p>
+          )}
+          {tokensPending && (
+            <p className="text-xs text-muted">
+              Loading token choices… ETH is available now.
+            </p>
+          )}
+          {tokensError && (
+            <p className="text-xs text-muted">
+              LI.FI token list unavailable. ETH sends remain available.
+            </p>
+          )}
+          <div className="flex flex-col gap-2 text-sm text-muted">
+            <p className="break-all" aria-live="polite">
+              {balanceText}
+            </p>
+            <button
+              type="button"
+              className="self-start underline"
+              disabled={
+                !reader ||
+                !isAddress(selectedAddress) ||
+                tokenBalance.isFetching
+              }
+              onClick={() => void tokenBalance.refetch()}
+            >
+              Refresh balance
+            </button>
+            <p className="text-xs">
+              Keep ETH on Base for network fees. Balance is checked again before
+              sending.
+            </p>
+          </div>
+          <label className="flex flex-col gap-2 text-sm text-default">
+            Recipient
+            <input
+              className="rounded-xl border px-3 py-2 bg-app border-default"
+              placeholder="0x…"
+              value={recipient}
+              onChange={(event) => {
+                edit();
+                setRecipient(event.target.value.trim());
+              }}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-default">
+            Amount
+            <input
+              className="rounded-xl border px-3 py-2 bg-app border-default"
+              inputMode="decimal"
+              placeholder="0.0"
+              value={amount}
+              maxLength={100}
+              onChange={(event) => {
+                edit();
+                setAmount(event.target.value);
+              }}
+            />
+          </label>
+          <DefaultButton type="submit" disabled={!reader || busy}>
+            {busy
+              ? 'Checking wallet…'
+              : prepared
+                ? 'Refresh review'
+                : 'Review send'}
+          </DefaultButton>
+        </fieldset>
+      </form>
+      {prepared && (
+        <section
+          aria-label="Review Base transfer"
+          className="flex flex-col gap-3 rounded-xl p-4 text-sm bg-elevated-nohover text-default"
+        >
+          <div className="font-semibold">Review send on Base</div>
+          <div className="break-all">
+            Amount: {formatUnits(prepared.units, prepared.decimals)}{' '}
+            {prepared.symbol}
+          </div>
+          <div className="break-all">From: {prepared.input.address}</div>
+          <div className="break-all">To: {prepared.input.recipient}</div>
+          {prepared.input.tokenAddress && (
+            <div className="break-all">
+              Token contract: {prepared.input.tokenAddress}
+            </div>
+          )}
+          <div>
+            Live balance: {formatUnits(prepared.balance, prepared.decimals)}{' '}
+            {prepared.symbol}
+          </div>
+          <div>
+            Estimated fee (L1 + L2): {formatEther(prepared.estimatedFee)} ETH
+          </div>
+          <p className="text-xs text-muted">
+            We check a 20% fee buffer, but this is not a fee cap. Final fees may
+            differ. Review expires after 60 seconds. Your wallet may request a
+            switch to Base.
+          </p>
+          <p className="text-xs text-muted">
+            For unusual tokens, transfer taxes or restrictions may change what
+            the recipient receives.
+          </p>
+          <DefaultButton
+            type="button"
+            disabled={busy || !provider}
+            onClick={() => void send()}
+          >
+            {busy ? 'Waiting for wallet…' : 'Confirm in wallet'}
+          </DefaultButton>
+        </section>
+      )}
+      {error && (
+        <p
+          role="alert"
+          className="rounded-xl bg-red-50 p-3 text-sm text-red-600"
+        >
+          {error}
+        </p>
+      )}
+      {hash && (
+        <div role="status" className="flex flex-col gap-2 text-sm text-default">
+          <p>{receiptStatus}</p>
+          <a
+            className="text-accent-primary hover:underline"
+            href={`https://basescan.org/tx/${receipt?.transactionHash ?? hash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View transaction on BaseScan
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSwap.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSwap.tsx
@@ -1,477 +1,645 @@
-import { FormEvent, useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import React, { FormEvent, useEffect, useRef, useState } from 'react';
 import {
   Address,
   encodeFunctionData,
   erc20Abi,
   formatUnits,
-  getAddress,
   Hash,
-  isAddress,
-  parseUnits,
+  toHex,
+  zeroAddress,
 } from 'viem';
-import { usePublicClient } from 'wagmi';
+import { base } from 'viem/chains';
+import { usePublicClient, useWaitForTransactionReceipt } from 'wagmi';
 
 import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
 import { useWallet } from '~/contexts/WalletProvider';
+import {
+  fetchFreshLifiAsset,
+  refreshLifiWallet,
+  useLifiAsset,
+  useLifiWalletTokens,
+} from '~/hooks/useLifiWallet';
+import { parseTransferAmount } from '~/utils/baseWalletTransfer';
 import { truncateAddress } from '~/utils/ethereumUtils';
+import { fetchLifiQuote, LifiQuote } from '~/utils/lifiSwap';
+import { LifiAsset, LifiToken, normalizeLifiAddress } from '~/utils/lifiWallet';
+import { readConfirmedAllowance } from '~/utils/readConfirmedAllowance';
+import { ensureBaseWalletAccount } from '~/utils/sendBaseNativeToken';
 
-const BASE_CHAIN_ID = 8453;
-const BASE_CHAIN_ID_HEX = '0x2105';
-const NATIVE_TOKEN_ADDRESS =
-  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as Address;
-
-type TokenDetails = {
-  address: Address;
-  symbol: string;
-  decimals: number;
-  balance: bigint;
-  isNative: boolean;
+type Review = {
+  quote: LifiQuote;
+  from: LifiAsset;
+  to: LifiAsset;
+  units: bigint;
+  allowance?: bigint;
 };
 
-type QuoteToken = {
-  address: Address;
-  symbol: string;
-  decimals: number;
+// Circle's native Base USDC, not bridged USDbC. Picker metadata only;
+// balances, token metadata and quotes still use the shared LI.FI/RPC path.
+// https://developers.circle.com/stablecoins/usdc-contract-addresses
+const BASE_USDC: LifiToken = {
+  chainId: base.id,
+  address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  symbol: 'USDC',
+  name: 'USD Coin',
+  decimals: 6,
 };
 
-type LiFiQuote = {
-  tool: string;
-  action: {
-    fromAmount: string;
-    fromToken: QuoteToken;
-    toToken: QuoteToken;
-  };
-  estimate: {
-    toAmount: string;
-    toAmountMin: string;
-    approvalAddress?: Address;
-  };
-  transactionRequest: {
-    to: Address;
-    data: `0x${string}`;
-    value?: `0x${string}`;
-    gasLimit?: `0x${string}`;
-    gasPrice?: `0x${string}`;
-  };
-};
+function isBaseUsdc(token: LifiToken) {
+  return (
+    token.chainId === base.id &&
+    token.address.toLowerCase() === BASE_USDC.address.toLowerCase()
+  );
+}
 
-type LiFiError = {
-  message?: string;
-  errors?: { message?: string }[];
-};
-
-function ExternalWalletSwap() {
+export function ExternalWalletSwap() {
   const { address, provider } = useWallet();
-  const publicClient = usePublicClient({ chainId: BASE_CHAIN_ID });
-  const [fromTokenInput, setFromTokenInput] = useState('ETH');
-  const [toTokenInput, setToTokenInput] = useState('');
+  const queryClient = useQueryClient();
+  const client = usePublicClient({ chainId: base.id });
+  const [fromInput, setFromInput] = useState('ETH');
+  const [toInput, setToInput] = useState('');
   const [amount, setAmount] = useState('');
-  const [fromToken, setFromToken] = useState<TokenDetails>();
-  const [toToken, setToToken] = useState<TokenDetails>();
-  const [quote, setQuote] = useState<LiFiQuote>();
-  const [isQuoting, setIsQuoting] = useState(false);
-  const [isExecuting, setIsExecuting] = useState(false);
+  const [review, setReview] = useState<Review>();
+  const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
   const [error, setError] = useState<string>();
-  const [transactionHash, setTransactionHash] = useState<Hash>();
+  const [hash, setHash] = useState<Hash>();
+  const [replacement, setReplacement] = useState<string>();
+  const [showUnverified, setShowUnverified] = useState(false);
+  const generation = useRef(0);
+  const locked = useRef(false);
+  const {
+    data: walletTokens,
+    isPending: tokensPending,
+    isError: tokensError,
+    isFetching: tokensFetching,
+    refetch: refetchTokens,
+  } = useLifiWalletTokens(address);
+  const allTokens = (walletTokens?.tokens ?? [])
+    .filter(
+      (token) => token.chainId === base.id && token.address !== zeroAddress,
+    )
+    .map((token) => (isBaseUsdc(token) ? BASE_USDC : token));
+  const unverifiedCount = allTokens.filter(
+    (token) => !isBaseUsdc(token) && token.verificationStatus !== 'verified',
+  ).length;
+  const tokenOptions = allTokens.filter(
+    (token) =>
+      isBaseUsdc(token) ||
+      showUnverified ||
+      token.verificationStatus === 'verified',
+  );
+  const buyTokenOptions = [
+    BASE_USDC,
+    ...tokenOptions.filter((token) => !isBaseUsdc(token)),
+  ];
+  const fromBalance = useLifiAsset(address, inputAddress(fromInput));
+  const toBalance = useLifiAsset(address, inputAddress(toInput));
+  const { data: receipt, isError: receiptError } = useWaitForTransactionReceipt(
+    {
+      hash,
+      chainId: base.id,
+      timeout: 60_000,
+      onReplaced: (transaction) => setReplacement(transaction.reason),
+    },
+  );
+  useEffect(() => {
+    generation.current += 1;
+    setReview(undefined);
+    setStatus(undefined);
+    return () => {
+      generation.current += 1;
+    };
+  }, [address, provider]);
+  const receiptHash = receipt?.transactionHash;
+  useEffect(() => {
+    if (address && receiptHash) {
+      void refreshLifiWallet(queryClient, address);
+    }
+  }, [receiptHash, address, queryClient]);
 
-  const clearQuote = () => {
-    setQuote(undefined);
+  const edit = () => {
+    generation.current += 1;
+    setReview(undefined);
     setStatus(undefined);
     setError(undefined);
-    setTransactionHash(undefined);
+  };
+  const load = async (token: Address) => {
+    if (!address || !client) {
+      throw new Error('Connect a wallet with a Base connection.');
+    }
+    return fetchFreshLifiAsset(queryClient, client, address, token);
+  };
+  const checkBalance = (asset: LifiAsset, units: bigint) => {
+    if (asset.balance < units) {
+      throw new Error(
+        `Insufficient ${asset.symbol} balance. Available: ${formatUnits(asset.balance, asset.decimals)} ${asset.symbol} on Base.`,
+      );
+    }
   };
 
-  const resolveToken = useCallback(
-    async (input: string): Promise<TokenDetails> => {
-      if (!address || !publicClient) {
-        throw new Error('Wallet or Base provider is unavailable.');
-      }
-
-      if (input.trim().toUpperCase() === 'ETH') {
-        return {
-          address: NATIVE_TOKEN_ADDRESS,
-          symbol: 'ETH',
-          decimals: 18,
-          balance: await publicClient.getBalance({ address }),
-          isNative: true,
-        };
-      }
-
-      if (!isAddress(input.trim())) {
-        throw new Error('Enter ETH or a valid Base token contract address.');
-      }
-
-      const tokenAddress = getAddress(input.trim());
-      try {
-        const [symbol, decimals, balance] = await Promise.all([
-          publicClient.readContract({
-            address: tokenAddress,
-            abi: erc20Abi,
-            functionName: 'symbol',
-          }),
-          publicClient.readContract({
-            address: tokenAddress,
-            abi: erc20Abi,
-            functionName: 'decimals',
-          }),
-          publicClient.readContract({
-            address: tokenAddress,
-            abi: erc20Abi,
-            functionName: 'balanceOf',
-            args: [address],
-          }),
-        ]);
-
-        return {
-          address: tokenAddress,
-          symbol,
-          decimals,
-          balance,
-          isNative: false,
-        };
-      } catch {
-        throw new Error('This address is not a readable ERC-20 token on Base.');
-      }
-    },
-    [address, publicClient],
-  );
-
-  const requestQuote = useCallback(
-    async (
-      resolvedFromToken: TokenDetails,
-      resolvedToToken: TokenDetails,
-      fromAmount: bigint,
-    ) => {
-      if (!address) {
-        throw new Error('Connect a wallet before requesting a quote.');
-      }
-
-      const params = new URLSearchParams({
-        fromChain: String(BASE_CHAIN_ID),
-        toChain: String(BASE_CHAIN_ID),
-        fromToken: resolvedFromToken.address,
-        toToken: resolvedToToken.address,
-        fromAmount: fromAmount.toString(),
-        fromAddress: address,
-        toAddress: address,
-        slippage: '0.005',
-        order: 'CHEAPEST',
-        integrator: 'farcaster-wallet-client',
-      });
-      const response = await fetch(`https://li.quest/v1/quote?${params}`);
-      const body = (await response.json()) as LiFiQuote | LiFiError;
-
-      if (!response.ok) {
-        const apiError = body as LiFiError;
-        throw new Error(
-          apiError.message ||
-            apiError.errors?.[0]?.message ||
-            'No swap route is available for these tokens.',
-        );
-      }
-
-      return body as LiFiQuote;
-    },
-    [address],
-  );
-
-  const resolveForm = useCallback(async () => {
-    const [resolvedFromToken, resolvedToToken] = await Promise.all([
-      resolveToken(fromTokenInput),
-      resolveToken(toTokenInput),
-    ]);
-
-    if (
-      resolvedFromToken.address.toLowerCase() ===
-      resolvedToToken.address.toLowerCase()
-    ) {
-      throw new Error('Choose two different tokens.');
-    }
-
-    let fromAmount: bigint;
-    try {
-      fromAmount = parseUnits(amount, resolvedFromToken.decimals);
-    } catch {
-      throw new Error('Enter a valid token amount.');
-    }
-
-    if (fromAmount <= 0n) {
-      throw new Error('Amount must be greater than zero.');
-    }
-    if (fromAmount > resolvedFromToken.balance) {
-      throw new Error(`Insufficient ${resolvedFromToken.symbol} balance.`);
-    }
-
-    setFromToken(resolvedFromToken);
-    setToToken(resolvedToToken);
-    return { resolvedFromToken, resolvedToToken, fromAmount };
-  }, [amount, fromTokenInput, resolveToken, toTokenInput]);
-
-  const handleQuote = async (event: FormEvent<HTMLFormElement>) => {
+  const getQuote = async (event: FormEvent) => {
     event.preventDefault();
+    if (!address || locked.current) {
+      return;
+    }
+    locked.current = true;
+    const version = generation.current;
+    setBusy(true);
     setError(undefined);
+    setReview(undefined);
     setStatus(undefined);
-    setTransactionHash(undefined);
-    setQuote(undefined);
-    setIsQuoting(true);
-
     try {
-      const { resolvedFromToken, resolvedToToken, fromAmount } =
-        await resolveForm();
-      setQuote(
-        await requestQuote(resolvedFromToken, resolvedToToken, fromAmount),
-      );
-    } catch (quoteError) {
-      setError(
-        quoteError instanceof Error
-          ? quoteError.message
-          : 'Could not create a swap quote.',
-      );
-    } finally {
-      setIsQuoting(false);
-    }
-  };
-
-  const sendApproval = async (
-    token: TokenDetails,
-    approvalAddress: Address,
-    approvalAmount: bigint,
-  ) => {
-    if (!address || !provider || !publicClient || token.isNative) {
-      return;
-    }
-
-    const allowance = await publicClient.readContract({
-      address: token.address,
-      abi: erc20Abi,
-      functionName: 'allowance',
-      args: [address, approvalAddress],
-    });
-    if (allowance >= approvalAmount) {
-      return;
-    }
-
-    setStatus(`Approve ${token.symbol} in your wallet…`);
-    const approvalHash = (await provider.request({
-      method: 'eth_sendTransaction',
-      params: [
-        {
-          from: address,
-          to: token.address,
-          data: encodeFunctionData({
-            abi: erc20Abi,
-            functionName: 'approve',
-            args: [approvalAddress, approvalAmount],
-          }),
-        },
-      ],
-    })) as Hash;
-    setStatus('Waiting for token approval…');
-    await publicClient.waitForTransactionReceipt({ hash: approvalHash });
-  };
-
-  const handleSwap = async () => {
-    if (!address || !provider || !publicClient || !quote || !fromToken) {
-      return;
-    }
-
-    setError(undefined);
-    setStatus(undefined);
-    setTransactionHash(undefined);
-    setIsExecuting(true);
-
-    try {
-      const currentChainId = await provider.request({ method: 'eth_chainId' });
-      if (Number(currentChainId) !== BASE_CHAIN_ID) {
-        setStatus('Switch to Base in your wallet…');
-        await provider.request({
-          method: 'wallet_switchEthereumChain',
-          params: [{ chainId: BASE_CHAIN_ID_HEX }],
+      const fromAddress = normalizeLifiAddress(fromInput);
+      const toAddress = normalizeLifiAddress(toInput);
+      if (fromAddress === toAddress) {
+        throw new Error('Choose two different tokens.');
+      }
+      const [from, to] = await Promise.all([
+        load(fromAddress),
+        load(toAddress),
+      ]);
+      const units = parseTransferAmount(amount, from.decimals);
+      checkBalance(from, units);
+      const quote = await fetchLifiQuote(address, from, to, units);
+      if (version !== generation.current) {
+        return;
+      }
+      let allowance: bigint | undefined;
+      if (from.address !== zeroAddress) {
+        const spender = quote.estimate.approvalAddress;
+        if (!client || !spender) {
+          throw new Error('Cannot check token approval for this quote.');
+        }
+        setStatus('Checking token approval…');
+        allowance = await client.readContract({
+          address: from.address,
+          abi: erc20Abi,
+          functionName: 'allowance',
+          args: [address, spender],
         });
       }
-
-      const approvalAmount = BigInt(quote.action.fromAmount);
-      if (quote.estimate.approvalAddress) {
-        await sendApproval(
-          fromToken,
-          quote.estimate.approvalAddress,
-          approvalAmount,
+      if (version === generation.current) {
+        setReview({ quote, from, to, units, allowance });
+        setStatus(undefined);
+      }
+    } catch (failure) {
+      if (version === generation.current) {
+        setStatus(undefined);
+        setError(
+          failure instanceof Error ? failure.message : 'Could not get a quote.',
         );
       }
+    } finally {
+      locked.current = false;
+      setBusy(false);
+    }
+  };
 
-      // LI.FI quotes expire quickly, so refresh after a possible approval.
-      const refreshedQuote = await requestQuote(
-        fromToken,
-        toToken!,
-        approvalAmount,
-      );
-      if (refreshedQuote.estimate.approvalAddress) {
-        await sendApproval(
-          fromToken,
-          refreshedQuote.estimate.approvalAddress,
-          approvalAmount,
-        );
+  const needsApproval = Boolean(
+    review &&
+    review.from.address !== zeroAddress &&
+    (review.allowance === undefined || review.allowance < review.units),
+  );
+
+  const swap = async () => {
+    if (!address || !provider || !client || !review || locked.current) {
+      return;
+    }
+    locked.current = true;
+    setBusy(true);
+    setError(undefined);
+    setStatus(undefined);
+    setHash(undefined);
+    setReplacement(undefined);
+    const version = generation.current;
+    const assertCurrent = () => {
+      if (version !== generation.current) {
+        throw new Error('Wallet or form changed. Get a new quote.');
       }
-
-      const transaction = refreshedQuote.transactionRequest;
-      setStatus('Review the swap in your wallet…');
-      const hash = (await provider.request({
+    };
+    try {
+      await ensureBaseWalletAccount(provider, address);
+      assertCurrent();
+      const from = await load(review.from.address);
+      assertCurrent();
+      if (from.decimals !== review.from.decimals) {
+        throw new Error('Token decimals changed. Get a new quote.');
+      }
+      checkBalance(from, review.units);
+      let quote = await fetchLifiQuote(address, from, review.to, review.units);
+      assertCurrent();
+      const checkChanges = (next: LifiQuote) => {
+        if (
+          BigInt(next.estimate.toAmountMin) <
+            BigInt(review.quote.estimate.toAmountMin) ||
+          next.estimate.approvalAddress?.toLowerCase() !==
+            review.quote.estimate.approvalAddress?.toLowerCase()
+        ) {
+          throw new Error(
+            'Quote changed. Get a new quote and review it before swapping.',
+          );
+        }
+      };
+      checkChanges(quote);
+      if (from.address !== zeroAddress) {
+        const spender = quote.estimate.approvalAddress;
+        if (!spender) {
+          throw new Error('LI.FI did not supply an approval address.');
+        }
+        const allowance = await client.readContract({
+          address: from.address,
+          abi: erc20Abi,
+          functionName: 'allowance',
+          args: [address, spender],
+        });
+        assertCurrent();
+        if (allowance < review.units) {
+          // Never turn a "Review swap" click into a new approval prompt.
+          if (!needsApproval) {
+            setReview({ ...review, quote, allowance });
+            setStatus(
+              'Allowance changed. Review the token approval before swapping.',
+            );
+            return;
+          }
+          await ensureBaseWalletAccount(provider, address, false);
+          assertCurrent();
+          setStatus(
+            `Approve exactly ${formatUnits(review.units, from.decimals)} ${from.symbol} in your wallet…`,
+          );
+          const approvalHash = (await provider.request({
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                chainId: toHex(base.id),
+                from: address,
+                to: from.address,
+                data: encodeFunctionData({
+                  abi: erc20Abi,
+                  functionName: 'approve',
+                  args: [spender, review.units],
+                }),
+              },
+            ],
+          })) as Hash;
+          assertCurrent();
+          setStatus('Waiting for token approval…');
+          const approvalReceipt = await client.waitForTransactionReceipt({
+            hash: approvalHash,
+          });
+          assertCurrent();
+          if (approvalReceipt.status !== 'success') {
+            throw new Error('Token approval reverted. Swap was not sent.');
+          }
+          setStatus(
+            'Approval confirmed. Checking allowance and refreshing the swap…',
+          );
+          quote = await fetchLifiQuote(address, from, review.to, review.units);
+          assertCurrent();
+          checkChanges(quote);
+          const approved = await readConfirmedAllowance({
+            read: () =>
+              client.readContract({
+                address: from.address,
+                abi: erc20Abi,
+                functionName: 'allowance',
+                args: [address, spender],
+                // Keep every retry pinned to the confirmed approval block.
+                blockNumber: approvalReceipt.blockNumber,
+              }),
+            assertCurrent,
+            onRetry: () =>
+              setStatus(
+                'Approval confirmed. Waiting for Base RPC to catch up…',
+              ),
+          });
+          assertCurrent();
+          if (approved < review.units) {
+            throw new Error(
+              'Token allowance is still insufficient. Swap was not sent.',
+            );
+          }
+          setReview({ ...review, quote, allowance: approved });
+          setStatus('Approval confirmed. Ready to review swap.');
+          return;
+        }
+        if (needsApproval) {
+          setReview({ ...review, quote, allowance });
+          setStatus('Already approved. Ready to review swap.');
+          return;
+        }
+      }
+      const latest = await load(from.address);
+      const native =
+        from.address === zeroAddress ? latest : await load(zeroAddress);
+      assertCurrent();
+      if (latest.decimals !== from.decimals) {
+        throw new Error('Token decimals changed. Get a new quote.');
+      }
+      checkBalance(latest, review.units);
+      const tx = quote.transactionRequest;
+      if (native.balance < BigInt(tx.value ?? '0')) {
+        throw new Error('Insufficient ETH on Base for the swap value.');
+      }
+      await ensureBaseWalletAccount(provider, address, false);
+      assertCurrent();
+      setStatus('Review swap and network fees in your wallet…');
+      const transactionHash = (await provider.request({
         method: 'eth_sendTransaction',
         params: [
           {
+            chainId: toHex(base.id),
             from: address,
-            to: transaction.to,
-            data: transaction.data,
-            value: transaction.value,
-            gas: transaction.gasLimit,
-            gasPrice: transaction.gasPrice,
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+            gas: tx.gasLimit,
+            gasPrice: tx.gasPrice,
           },
         ],
       })) as Hash;
-
-      setTransactionHash(hash);
-      setStatus('Swap submitted');
-      setQuote(undefined);
-    } catch (swapError) {
-      setStatus(undefined);
-      setError(
-        swapError instanceof Error ? swapError.message : 'Swap was not sent.',
-      );
+      setHash(transactionHash);
+      setStatus('Swap submitted. Waiting for confirmation…');
+      setReview(undefined);
+      void refreshLifiWallet(queryClient, address);
+    } catch (failure) {
+      if (version === generation.current) {
+        setError(
+          failure instanceof Error ? failure.message : 'Swap was not sent.',
+        );
+        setStatus(undefined);
+        setReview(undefined);
+      }
     } finally {
-      setIsExecuting(false);
+      locked.current = false;
+      setBusy(false);
     }
   };
 
+  const transactionStatus =
+    replacement === 'cancelled'
+      ? 'Swap transaction cancelled.'
+      : replacement === 'replaced'
+        ? 'Transaction replaced. Check BaseScan.'
+        : receipt
+          ? receipt.status === 'success'
+            ? 'Swap confirmed on Base.'
+            : 'Swap reverted on Base.'
+          : receiptError
+            ? 'Confirmation unavailable. Check BaseScan before trying again.'
+            : 'Swap submitted. Waiting for confirmation…';
+
   return (
     <div className="flex flex-col gap-4 pt-4">
-      <div className="rounded-xl p-3 text-xs text-muted bg-elevated-nohover">
-        Base only. Enter <span className="font-semibold">ETH</span> or paste a
-        Base ERC-20 contract address. Verify contracts before approving them.
-      </div>
-
-      <form className="flex flex-col gap-4" onSubmit={handleQuote}>
-        <TokenInput
-          label="Sell token"
-          value={fromTokenInput}
-          token={fromToken}
-          onChange={(value) => {
-            setFromTokenInput(value);
-            setFromToken(undefined);
-            clearQuote();
-          }}
-        />
-        <label className="flex flex-col gap-2 text-sm text-default">
-          Amount
-          <input
-            className="rounded-xl border px-3 py-2 bg-app border-default"
-            inputMode="decimal"
-            placeholder="0.0"
-            value={amount}
-            onChange={(event) => {
-              setAmount(event.target.value);
-              clearQuote();
+      <p className="rounded-xl p-3 text-xs text-muted bg-elevated-nohover">
+        Base only. LI.FI supplies token data and swap routes. Choose a wallet
+        token or enter ETH / a Base contract. Verify contracts before approving.
+      </p>
+      <form className="flex flex-col gap-4" onSubmit={getQuote}>
+        <fieldset className="flex min-w-0 flex-col gap-4" disabled={busy}>
+          {unverifiedCount > 0 && (
+            <label className="flex items-center gap-2 text-sm text-muted">
+              <input
+                type="checkbox"
+                checked={showUnverified}
+                onChange={(event) => setShowUnverified(event.target.checked)}
+              />
+              Show unverified tokens ({unverifiedCount})
+            </label>
+          )}
+          {showUnverified && (
+            <p className="text-xs text-muted">
+              Unverified tokens may include spam. Check the contract before
+              approving; names and verification labels are not a safety
+              guarantee.
+            </p>
+          )}
+          {tokensPending && (
+            <p className="text-xs text-muted">
+              Loading wallet token choices… You can still enter a contract.
+            </p>
+          )}
+          {tokensError && (
+            <p className="text-xs text-muted">
+              LI.FI token list unavailable. Retry or enter a contract below.
+            </p>
+          )}
+          <button
+            type="button"
+            className="self-start text-xs text-muted underline"
+            disabled={tokensFetching}
+            onClick={() => void refetchTokens()}
+          >
+            {tokensFetching ? 'Refreshing token list…' : 'Refresh token list'}
+          </button>
+          <TokenInput
+            label="Sell token"
+            tokens={tokenOptions}
+            value={fromInput}
+            asset={fromBalance.isError ? undefined : fromBalance.data}
+            error={fromBalance.isError}
+            onChange={(value) => {
+              edit();
+              setFromInput(value);
             }}
           />
-        </label>
-        <TokenInput
-          label="Buy token"
-          value={toTokenInput}
-          token={toToken}
-          onChange={(value) => {
-            setToTokenInput(value);
-            setToToken(undefined);
-            clearQuote();
-          }}
-        />
-
-        {!quote && (
-          <DefaultButton type="submit" isLoading={isQuoting}>
-            Get quote
+          <label className="flex flex-col gap-2 text-sm text-default">
+            Amount
+            <input
+              className="rounded-xl border px-3 py-2 bg-app border-default"
+              inputMode="decimal"
+              placeholder="0.0"
+              value={amount}
+              maxLength={100}
+              onChange={(event) => {
+                edit();
+                setAmount(event.target.value);
+              }}
+            />
+          </label>
+          <TokenInput
+            label="Buy token"
+            tokens={buyTokenOptions}
+            value={toInput}
+            asset={toBalance.isError ? undefined : toBalance.data}
+            error={toBalance.isError}
+            onChange={(value) => {
+              edit();
+              setToInput(value);
+            }}
+          />
+          <DefaultButton type="submit" disabled={busy || !address || !client}>
+            {busy ? 'Checking wallet…' : review ? 'Refresh quote' : 'Get quote'}
           </DefaultButton>
-        )}
+        </fieldset>
       </form>
-
-      {quote && toToken && (
-        <div className="rounded-xl p-4 bg-elevated-nohover">
+      {review && (
+        <section
+          aria-label="Review Base swap"
+          className="rounded-xl p-4 bg-elevated-nohover"
+        >
           <div className="text-xs text-muted">Estimated receive</div>
-          <div className="mt-1 text-xl font-semibold text-default">
-            {formatTokenAmount(quote.estimate.toAmount, toToken)}
+          <div className="mt-1 break-all text-xl font-semibold text-default">
+            {formatUnits(
+              BigInt(review.quote.estimate.toAmount),
+              review.to.decimals,
+            )}{' '}
+            {review.to.symbol}
           </div>
-          <div className="mt-1 text-xs text-muted">
-            Minimum {formatTokenAmount(quote.estimate.toAmountMin, toToken)} ·
-            Route: {quote.tool}
+          <div className="mt-1 break-all text-xs text-muted">
+            Minimum{' '}
+            {formatUnits(
+              BigInt(review.quote.estimate.toAmountMin),
+              review.to.decimals,
+            )}{' '}
+            {review.to.symbol} · Route: {review.quote.tool}
+          </div>
+          <div aria-label="Token approval" className="mt-3 text-xs text-muted">
+            {review.from.address === zeroAddress ? (
+              <p>Native ETH does not need token approval.</p>
+            ) : (
+              <>
+                <p>
+                  Approved:{' '}
+                  {formatUnits(review.allowance ?? 0n, review.from.decimals)}{' '}
+                  {review.from.symbol}
+                  {' · '}Required:{' '}
+                  {formatUnits(review.units, review.from.decimals)}{' '}
+                  {review.from.symbol}
+                </p>
+                <p className="break-all">
+                  Base spender: {review.quote.estimate.approvalAddress}
+                </p>
+                <p>
+                  {needsApproval
+                    ? 'Approve the exact sell amount, wait for confirmation, then review the swap.'
+                    : 'Sufficient approval. Allowance will be checked again before swapping.'}
+                </p>
+              </>
+            )}
           </div>
           <DefaultButton
+            type="button"
             className="mt-4 w-full"
-            isLoading={isExecuting}
-            onClick={handleSwap}
+            disabled={busy}
+            onClick={() => void swap()}
           >
-            Review swap
+            {busy
+              ? 'Working…'
+              : needsApproval
+                ? `Approve ${review.from.symbol}`
+                : 'Review swap'}
           </DefaultButton>
-        </div>
+        </section>
       )}
-
-      {status && (
-        <div className="rounded-xl p-3 text-sm bg-elevated-nohover text-default">
-          {status}
-        </div>
+      {(status || hash) && (
+        <p
+          role="status"
+          className="rounded-xl p-3 text-sm bg-elevated-nohover text-default"
+        >
+          {hash ? transactionStatus : status}
+        </p>
       )}
       {error && (
-        <div className="rounded-xl bg-red-50 p-3 text-sm text-red-600">
+        <p
+          role="alert"
+          className="rounded-xl bg-red-50 p-3 text-sm text-red-600"
+        >
           {error}
-        </div>
+        </p>
       )}
-      {transactionHash && (
+      {hash && (
         <a
           className="text-accent-primary text-sm hover:underline"
-          href={`https://basescan.org/tx/${transactionHash}`}
+          href={`https://basescan.org/tx/${receipt?.transactionHash ?? hash}`}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
         >
-          View {truncateAddress(transactionHash, 8)} on BaseScan
+          View {truncateAddress(hash, 8)} on BaseScan
         </a>
       )}
     </div>
   );
 }
 
+function inputAddress(input: string) {
+  try {
+    return normalizeLifiAddress(input);
+  } catch {
+    return undefined;
+  }
+}
+
 function TokenInput({
   label,
+  tokens,
   value,
-  token,
+  asset,
+  error,
   onChange,
 }: {
   label: string;
+  tokens: LifiToken[];
   value: string;
-  token?: TokenDetails;
+  asset?: LifiAsset;
+  error: boolean;
   onChange: (value: string) => void;
 }) {
+  const address = inputAddress(value);
+  const selected =
+    address === zeroAddress
+      ? 'ETH'
+      : (tokens.find(
+          (token) => token.address.toLowerCase() === address?.toLowerCase(),
+        )?.address ?? 'custom');
   return (
-    <label className="flex flex-col gap-2 text-sm text-default">
-      {label}
-      <input
-        className="rounded-xl border px-3 py-2 bg-app border-default"
-        autoCapitalize="none"
-        autoCorrect="off"
-        placeholder="ETH or 0x…"
-        value={value}
-        onChange={(event) => onChange(event.target.value.trim())}
-      />
-      {token && (
-        <span className="text-xs text-muted">
-          {token.symbol} balance: {formatTokenAmount(token.balance, token)}
-        </span>
-      )}
-    </label>
+    <div className="flex flex-col gap-2 text-sm text-default">
+      <label className="flex flex-col gap-2">
+        {label === 'Sell token' ? 'Choose sell asset' : 'Choose buy asset'}
+        <select
+          className="w-full rounded-xl border px-3 py-2 bg-app border-default"
+          value={selected}
+          onChange={(event) =>
+            onChange(event.target.value === 'custom' ? '' : event.target.value)
+          }
+        >
+          <option value="ETH">ETH — native asset</option>
+          {tokens.map((token) => (
+            <option key={token.address} value={token.address}>
+              {token.symbol} —{' '}
+              {isBaseUsdc(token)
+                ? 'native USDC on Base'
+                : truncateAddress(token.address, 4)}
+              {!isBaseUsdc(token) && token.verificationStatus !== 'verified'
+                ? ' (unverified)'
+                : ''}
+            </option>
+          ))}
+          <option value="custom">Enter a contract below…</option>
+        </select>
+      </label>
+      <label className="flex flex-col gap-2">
+        {label}
+        <input
+          className="rounded-xl border px-3 py-2 bg-app border-default"
+          autoCapitalize="none"
+          autoCorrect="off"
+          placeholder="ETH or 0x…"
+          value={value}
+          onChange={(event) => onChange(event.target.value.trim())}
+        />
+      </label>
+      <span className="break-all text-xs text-muted">
+        {error
+          ? 'Balance unavailable. Check the contract or refresh.'
+          : asset
+            ? `Available on Base: ${formatUnits(asset.balance, asset.decimals)} ${asset.symbol}`
+            : inputAddress(value)
+              ? 'Loading balance on Base…'
+              : 'Enter a token contract.'}
+      </span>
+    </div>
   );
 }
-
-function formatTokenAmount(amount: string | bigint, token: TokenDetails) {
-  const formatted = Number(
-    formatUnits(BigInt(amount), token.decimals),
-  ).toLocaleString(undefined, { maximumFractionDigits: 6 });
-  return `${formatted} ${token.symbol}`;
-}
-
-export { ExternalWalletSwap };

--- a/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSwap.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/ExternalWalletSwap.tsx
@@ -1,0 +1,477 @@
+import { FormEvent, useCallback, useState } from 'react';
+import {
+  Address,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  Hash,
+  isAddress,
+  parseUnits,
+} from 'viem';
+import { usePublicClient } from 'wagmi';
+
+import { DefaultButton } from '~/components/forms/buttons/DefaultButton';
+import { useWallet } from '~/contexts/WalletProvider';
+import { truncateAddress } from '~/utils/ethereumUtils';
+
+const BASE_CHAIN_ID = 8453;
+const BASE_CHAIN_ID_HEX = '0x2105';
+const NATIVE_TOKEN_ADDRESS =
+  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as Address;
+
+type TokenDetails = {
+  address: Address;
+  symbol: string;
+  decimals: number;
+  balance: bigint;
+  isNative: boolean;
+};
+
+type QuoteToken = {
+  address: Address;
+  symbol: string;
+  decimals: number;
+};
+
+type LiFiQuote = {
+  tool: string;
+  action: {
+    fromAmount: string;
+    fromToken: QuoteToken;
+    toToken: QuoteToken;
+  };
+  estimate: {
+    toAmount: string;
+    toAmountMin: string;
+    approvalAddress?: Address;
+  };
+  transactionRequest: {
+    to: Address;
+    data: `0x${string}`;
+    value?: `0x${string}`;
+    gasLimit?: `0x${string}`;
+    gasPrice?: `0x${string}`;
+  };
+};
+
+type LiFiError = {
+  message?: string;
+  errors?: { message?: string }[];
+};
+
+function ExternalWalletSwap() {
+  const { address, provider } = useWallet();
+  const publicClient = usePublicClient({ chainId: BASE_CHAIN_ID });
+  const [fromTokenInput, setFromTokenInput] = useState('ETH');
+  const [toTokenInput, setToTokenInput] = useState('');
+  const [amount, setAmount] = useState('');
+  const [fromToken, setFromToken] = useState<TokenDetails>();
+  const [toToken, setToToken] = useState<TokenDetails>();
+  const [quote, setQuote] = useState<LiFiQuote>();
+  const [isQuoting, setIsQuoting] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [status, setStatus] = useState<string>();
+  const [error, setError] = useState<string>();
+  const [transactionHash, setTransactionHash] = useState<Hash>();
+
+  const clearQuote = () => {
+    setQuote(undefined);
+    setStatus(undefined);
+    setError(undefined);
+    setTransactionHash(undefined);
+  };
+
+  const resolveToken = useCallback(
+    async (input: string): Promise<TokenDetails> => {
+      if (!address || !publicClient) {
+        throw new Error('Wallet or Base provider is unavailable.');
+      }
+
+      if (input.trim().toUpperCase() === 'ETH') {
+        return {
+          address: NATIVE_TOKEN_ADDRESS,
+          symbol: 'ETH',
+          decimals: 18,
+          balance: await publicClient.getBalance({ address }),
+          isNative: true,
+        };
+      }
+
+      if (!isAddress(input.trim())) {
+        throw new Error('Enter ETH or a valid Base token contract address.');
+      }
+
+      const tokenAddress = getAddress(input.trim());
+      try {
+        const [symbol, decimals, balance] = await Promise.all([
+          publicClient.readContract({
+            address: tokenAddress,
+            abi: erc20Abi,
+            functionName: 'symbol',
+          }),
+          publicClient.readContract({
+            address: tokenAddress,
+            abi: erc20Abi,
+            functionName: 'decimals',
+          }),
+          publicClient.readContract({
+            address: tokenAddress,
+            abi: erc20Abi,
+            functionName: 'balanceOf',
+            args: [address],
+          }),
+        ]);
+
+        return {
+          address: tokenAddress,
+          symbol,
+          decimals,
+          balance,
+          isNative: false,
+        };
+      } catch {
+        throw new Error('This address is not a readable ERC-20 token on Base.');
+      }
+    },
+    [address, publicClient],
+  );
+
+  const requestQuote = useCallback(
+    async (
+      resolvedFromToken: TokenDetails,
+      resolvedToToken: TokenDetails,
+      fromAmount: bigint,
+    ) => {
+      if (!address) {
+        throw new Error('Connect a wallet before requesting a quote.');
+      }
+
+      const params = new URLSearchParams({
+        fromChain: String(BASE_CHAIN_ID),
+        toChain: String(BASE_CHAIN_ID),
+        fromToken: resolvedFromToken.address,
+        toToken: resolvedToToken.address,
+        fromAmount: fromAmount.toString(),
+        fromAddress: address,
+        toAddress: address,
+        slippage: '0.005',
+        order: 'CHEAPEST',
+        integrator: 'farcaster-wallet-client',
+      });
+      const response = await fetch(`https://li.quest/v1/quote?${params}`);
+      const body = (await response.json()) as LiFiQuote | LiFiError;
+
+      if (!response.ok) {
+        const apiError = body as LiFiError;
+        throw new Error(
+          apiError.message ||
+            apiError.errors?.[0]?.message ||
+            'No swap route is available for these tokens.',
+        );
+      }
+
+      return body as LiFiQuote;
+    },
+    [address],
+  );
+
+  const resolveForm = useCallback(async () => {
+    const [resolvedFromToken, resolvedToToken] = await Promise.all([
+      resolveToken(fromTokenInput),
+      resolveToken(toTokenInput),
+    ]);
+
+    if (
+      resolvedFromToken.address.toLowerCase() ===
+      resolvedToToken.address.toLowerCase()
+    ) {
+      throw new Error('Choose two different tokens.');
+    }
+
+    let fromAmount: bigint;
+    try {
+      fromAmount = parseUnits(amount, resolvedFromToken.decimals);
+    } catch {
+      throw new Error('Enter a valid token amount.');
+    }
+
+    if (fromAmount <= 0n) {
+      throw new Error('Amount must be greater than zero.');
+    }
+    if (fromAmount > resolvedFromToken.balance) {
+      throw new Error(`Insufficient ${resolvedFromToken.symbol} balance.`);
+    }
+
+    setFromToken(resolvedFromToken);
+    setToToken(resolvedToToken);
+    return { resolvedFromToken, resolvedToToken, fromAmount };
+  }, [amount, fromTokenInput, resolveToken, toTokenInput]);
+
+  const handleQuote = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(undefined);
+    setStatus(undefined);
+    setTransactionHash(undefined);
+    setQuote(undefined);
+    setIsQuoting(true);
+
+    try {
+      const { resolvedFromToken, resolvedToToken, fromAmount } =
+        await resolveForm();
+      setQuote(
+        await requestQuote(resolvedFromToken, resolvedToToken, fromAmount),
+      );
+    } catch (quoteError) {
+      setError(
+        quoteError instanceof Error
+          ? quoteError.message
+          : 'Could not create a swap quote.',
+      );
+    } finally {
+      setIsQuoting(false);
+    }
+  };
+
+  const sendApproval = async (
+    token: TokenDetails,
+    approvalAddress: Address,
+    approvalAmount: bigint,
+  ) => {
+    if (!address || !provider || !publicClient || token.isNative) {
+      return;
+    }
+
+    const allowance = await publicClient.readContract({
+      address: token.address,
+      abi: erc20Abi,
+      functionName: 'allowance',
+      args: [address, approvalAddress],
+    });
+    if (allowance >= approvalAmount) {
+      return;
+    }
+
+    setStatus(`Approve ${token.symbol} in your wallet…`);
+    const approvalHash = (await provider.request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: address,
+          to: token.address,
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: 'approve',
+            args: [approvalAddress, approvalAmount],
+          }),
+        },
+      ],
+    })) as Hash;
+    setStatus('Waiting for token approval…');
+    await publicClient.waitForTransactionReceipt({ hash: approvalHash });
+  };
+
+  const handleSwap = async () => {
+    if (!address || !provider || !publicClient || !quote || !fromToken) {
+      return;
+    }
+
+    setError(undefined);
+    setStatus(undefined);
+    setTransactionHash(undefined);
+    setIsExecuting(true);
+
+    try {
+      const currentChainId = await provider.request({ method: 'eth_chainId' });
+      if (Number(currentChainId) !== BASE_CHAIN_ID) {
+        setStatus('Switch to Base in your wallet…');
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: BASE_CHAIN_ID_HEX }],
+        });
+      }
+
+      const approvalAmount = BigInt(quote.action.fromAmount);
+      if (quote.estimate.approvalAddress) {
+        await sendApproval(
+          fromToken,
+          quote.estimate.approvalAddress,
+          approvalAmount,
+        );
+      }
+
+      // LI.FI quotes expire quickly, so refresh after a possible approval.
+      const refreshedQuote = await requestQuote(
+        fromToken,
+        toToken!,
+        approvalAmount,
+      );
+      if (refreshedQuote.estimate.approvalAddress) {
+        await sendApproval(
+          fromToken,
+          refreshedQuote.estimate.approvalAddress,
+          approvalAmount,
+        );
+      }
+
+      const transaction = refreshedQuote.transactionRequest;
+      setStatus('Review the swap in your wallet…');
+      const hash = (await provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: address,
+            to: transaction.to,
+            data: transaction.data,
+            value: transaction.value,
+            gas: transaction.gasLimit,
+            gasPrice: transaction.gasPrice,
+          },
+        ],
+      })) as Hash;
+
+      setTransactionHash(hash);
+      setStatus('Swap submitted');
+      setQuote(undefined);
+    } catch (swapError) {
+      setStatus(undefined);
+      setError(
+        swapError instanceof Error ? swapError.message : 'Swap was not sent.',
+      );
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <div className="rounded-xl p-3 text-xs text-muted bg-elevated-nohover">
+        Base only. Enter <span className="font-semibold">ETH</span> or paste a
+        Base ERC-20 contract address. Verify contracts before approving them.
+      </div>
+
+      <form className="flex flex-col gap-4" onSubmit={handleQuote}>
+        <TokenInput
+          label="Sell token"
+          value={fromTokenInput}
+          token={fromToken}
+          onChange={(value) => {
+            setFromTokenInput(value);
+            setFromToken(undefined);
+            clearQuote();
+          }}
+        />
+        <label className="flex flex-col gap-2 text-sm text-default">
+          Amount
+          <input
+            className="rounded-xl border px-3 py-2 bg-app border-default"
+            inputMode="decimal"
+            placeholder="0.0"
+            value={amount}
+            onChange={(event) => {
+              setAmount(event.target.value);
+              clearQuote();
+            }}
+          />
+        </label>
+        <TokenInput
+          label="Buy token"
+          value={toTokenInput}
+          token={toToken}
+          onChange={(value) => {
+            setToTokenInput(value);
+            setToToken(undefined);
+            clearQuote();
+          }}
+        />
+
+        {!quote && (
+          <DefaultButton type="submit" isLoading={isQuoting}>
+            Get quote
+          </DefaultButton>
+        )}
+      </form>
+
+      {quote && toToken && (
+        <div className="rounded-xl p-4 bg-elevated-nohover">
+          <div className="text-xs text-muted">Estimated receive</div>
+          <div className="mt-1 text-xl font-semibold text-default">
+            {formatTokenAmount(quote.estimate.toAmount, toToken)}
+          </div>
+          <div className="mt-1 text-xs text-muted">
+            Minimum {formatTokenAmount(quote.estimate.toAmountMin, toToken)} ·
+            Route: {quote.tool}
+          </div>
+          <DefaultButton
+            className="mt-4 w-full"
+            isLoading={isExecuting}
+            onClick={handleSwap}
+          >
+            Review swap
+          </DefaultButton>
+        </div>
+      )}
+
+      {status && (
+        <div className="rounded-xl p-3 text-sm bg-elevated-nohover text-default">
+          {status}
+        </div>
+      )}
+      {error && (
+        <div className="rounded-xl bg-red-50 p-3 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+      {transactionHash && (
+        <a
+          className="text-accent-primary text-sm hover:underline"
+          href={`https://basescan.org/tx/${transactionHash}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View {truncateAddress(transactionHash, 8)} on BaseScan
+        </a>
+      )}
+    </div>
+  );
+}
+
+function TokenInput({
+  label,
+  value,
+  token,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  token?: TokenDetails;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-2 text-sm text-default">
+      {label}
+      <input
+        className="rounded-xl border px-3 py-2 bg-app border-default"
+        autoCapitalize="none"
+        autoCorrect="off"
+        placeholder="ETH or 0x…"
+        value={value}
+        onChange={(event) => onChange(event.target.value.trim())}
+      />
+      {token && (
+        <span className="text-xs text-muted">
+          {token.symbol} balance: {formatTokenAmount(token.balance, token)}
+        </span>
+      )}
+    </label>
+  );
+}
+
+function formatTokenAmount(amount: string | bigint, token: TokenDetails) {
+  const formatted = Number(
+    formatUnits(BigInt(amount), token.decimals),
+  ).toLocaleString(undefined, { maximumFractionDigits: 6 });
+  return `${formatted} ${token.symbol}`;
+}
+
+export { ExternalWalletSwap };

--- a/apps/farcaster-web/src/components/rightSidebar/FloatingWallet.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/FloatingWallet.tsx
@@ -18,8 +18,10 @@ import {
 } from '~/components/EmbeddedWallet';
 import { WalletIcon } from '~/components/icons/WalletIcon';
 import { MinimizableWindowHostVariant } from '~/components/MinimizableWindowHost';
+import { ExternalWalletPanel } from '~/components/rightSidebar/ExternalWalletPanel';
 import { useOpenableWarpcastWallet } from '~/contexts/OpenableWarpcastWalletContext';
 import { useWalletLocked } from '~/contexts/WalletLockedProvider';
+import { useWallet } from '~/contexts/WalletProvider';
 import { useCurrentUser } from '~/hooks/data/useCurrentUser';
 import { cn } from '~/lib/utils';
 import { truncateAddress } from '~/utils/ethereumUtils';
@@ -32,6 +34,8 @@ function FloatingWallet({
   const { fid } = useCurrentUser();
   const { data: verifications } = useVerificationsQuery({ fid });
   const { trackEvent } = useTrackEvent();
+  const { address, preferredWallet } = useWallet();
+  const usesExternalWallet = preferredWallet !== 'warpcast';
 
   // Due to limitations in Skia, we need to first render the wallet full width
   // then transition to the correct width.
@@ -104,7 +108,7 @@ function FloatingWallet({
 
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
 
-  if (!warpletAddress) {
+  if (!warpletAddress && !usesExternalWallet && !address) {
     return null;
   }
 
@@ -177,12 +181,15 @@ function FloatingWallet({
             },
           )}
         >
-          {hasBeenOpened && (
-            <EmbeddedWalletIframe
-              surface="full_warplet"
-              disableClicks={dropdownIsOpen}
-            />
-          )}
+          {hasBeenOpened &&
+            (usesExternalWallet ? (
+              <ExternalWalletPanel />
+            ) : (
+              <EmbeddedWalletIframe
+                surface="full_warplet"
+                disableClicks={dropdownIsOpen}
+              />
+            ))}
         </div>
       </div>
     </>

--- a/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletPortfolio.test.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletPortfolio.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ApiEthFungibleTokenPosition } from 'farcaster-client-data';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExternalWalletPortfolio } from '~/components/rightSidebar/ExternalWalletPortfolio';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  signedIn: vi.fn(),
+  refetch: vi.fn(),
+}));
+vi.mock('farcaster-client-hooks', () => ({
+  useWalletPositionsQuery: mocks.query,
+}));
+vi.mock('~/hooks/data/useIsSignedIn', () => ({
+  useIsSignedIn: mocks.signedIn,
+}));
+vi.mock('~/components/forms/buttons/DefaultButton', () => ({
+  DefaultButton: ({
+    children,
+    onClick,
+    disabled,
+  }: React.ComponentProps<'button'>) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+const address = '0x1111111111111111111111111111111111111111';
+const otherAddress = '0x2222222222222222222222222222222222222222';
+const position = (overrides: Partial<ApiEthFungibleTokenPosition> = {}) =>
+  ({
+    id: 'token',
+    chain: 'base',
+    symbol: 'TEST',
+    address,
+    decimals: 6,
+    quantity: { int: '1000000', float: 1 },
+    value: 2,
+    ...overrides,
+  }) as ApiEthFungibleTokenPosition;
+const result = (positions: ApiEthFungibleTokenPosition[]) => ({
+  data: { positions },
+  isPending: false,
+  isError: false,
+  isFetching: false,
+  refetch: mocks.refetch,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.signedIn.mockReturnValue(true);
+  mocks.query.mockReturnValue(result([position()]));
+});
+afterEach(cleanup);
+
+describe('ExternalWalletPortfolio', () => {
+  it('excludes native ETH from rows and hidden-token counts, but keeps WETH', () => {
+    mocks.query.mockReturnValue(
+      result([
+        position({
+          id: 'native',
+          symbol: 'ETH',
+          address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+          hidden: true,
+        }),
+        position({
+          id: 'wrapped',
+          symbol: 'WETH',
+          address: '0x4200000000000000000000000000000000000006',
+          hidden: true,
+        }),
+      ]),
+    );
+    render(<ExternalWalletPortfolio address={address} />);
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: 'Show hidden tokens (1)' }),
+    );
+    expect(screen.queryByText('ETH', { exact: true })).toBeNull();
+    expect(screen.getByText('WETH')).toBeTruthy();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('shows a clear empty-token state for an ETH-only wallet', () => {
+    mocks.query.mockReturnValue(
+      result([
+        position({
+          symbol: 'ETH',
+          address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        }),
+      ]),
+    );
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(
+      screen.getByText(
+        'No Base token holdings to show. Native ETH is shown above.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole('listitem')).toBeNull();
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('requests holdings by connected address without previous-account placeholders', () => {
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { address },
+        enabled: true,
+        keepPreviousData: false,
+      }),
+    );
+    expect(screen.getByText('TEST')).toBeTruthy();
+    expect(screen.getByText('$2.00')).toBeTruthy();
+  });
+
+  it('excludes other networks and reveals hidden tokens only when selected', () => {
+    mocks.query.mockReturnValue(
+      result([
+        position(),
+        position({ id: 'hidden', symbol: 'HIDDEN', hidden: true }),
+        position({ id: 'other', symbol: 'OTHER-CHAIN', chain: 'ethereum' }),
+      ]),
+    );
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(screen.queryByText('HIDDEN')).toBeNull();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(screen.getByText('HIDDEN')).toBeTruthy();
+    expect(screen.queryByText('OTHER-CHAIN')).toBeNull();
+  });
+
+  it('shows a loading state when there is no data yet', () => {
+    mocks.query.mockReturnValue({
+      ...result([]),
+      data: undefined,
+      isPending: true,
+      isFetching: true,
+    });
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(screen.getByRole('status').textContent).toContain('Loading');
+  });
+
+  it('shows an empty state and refreshes on request', () => {
+    mocks.query.mockReturnValue(result([]));
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(
+      screen.getByText(
+        'No Base token holdings to show. Native ETH is shown above.',
+      ),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh tokens' }));
+    expect(mocks.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('distinguishes a failed lookup from an empty portfolio', () => {
+    mocks.query.mockReturnValue({
+      ...result([]),
+      data: undefined,
+      isError: true,
+    });
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(screen.getByRole('alert').textContent).toContain('Could not load');
+    expect(
+      screen.queryByText(
+        'No Base token holdings to show. Native ETH is shown above.',
+      ),
+    ).toBeNull();
+  });
+
+  it('warns when cached balances could not be refreshed', () => {
+    mocks.query.mockReturnValue({ ...result([position()]), isError: true });
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(screen.getByRole('alert').textContent).toContain('out of date');
+    expect(screen.getByText('TEST')).toBeTruthy();
+  });
+
+  it('does not fetch or display cached holdings when signed out', () => {
+    mocks.signedIn.mockReturnValue(false);
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(screen.queryByText('TEST')).toBeNull();
+  });
+
+  it('changes the query address and clears the old view when switching wallets', () => {
+    const { rerender } = render(
+      <ExternalWalletPortfolio key={address} address={address} />,
+    );
+    mocks.query.mockReturnValue({
+      ...result([]),
+      data: undefined,
+      isPending: true,
+    });
+    rerender(
+      <ExternalWalletPortfolio key={otherAddress} address={otherAddress} />,
+    );
+    expect(mocks.query).toHaveBeenLastCalledWith(
+      expect.objectContaining({ params: { address: otherAddress } }),
+    );
+    expect(screen.queryByText('TEST')).toBeNull();
+  });
+
+  it('treats token claim links as plain untrusted text', () => {
+    mocks.query.mockReturnValue(
+      result([position({ symbol: 'Claim https://example.invalid' })]),
+    );
+    render(<ExternalWalletPortfolio address={address} />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('href')).toBe(
+      `https://basescan.org/token/${address}`,
+    );
+  });
+
+  it('limits long lists until the user requests more tokens', () => {
+    mocks.query.mockReturnValue(
+      result(
+        Array.from({ length: 25 }, (_, i) =>
+          position({ id: String(i), symbol: `TOKEN-${i}` }),
+        ),
+      ),
+    );
+    render(<ExternalWalletPortfolio address={address} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(20);
+    fireEvent.click(screen.getByRole('button', { name: /Show more tokens/ }));
+    expect(screen.getAllByRole('listitem')).toHaveLength(25);
+  });
+});

--- a/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletPortfolio.test.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletPortfolio.test.tsx
@@ -1,22 +1,24 @@
 // @vitest-environment jsdom
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ApiEthFungibleTokenPosition } from 'farcaster-client-data';
 import React from 'react';
+import { zeroAddress } from 'viem';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ExternalWalletPortfolio } from '~/components/rightSidebar/ExternalWalletPortfolio';
 
 const mocks = vi.hoisted(() => ({
-  query: vi.fn(),
-  signedIn: vi.fn(),
-  refetch: vi.fn(),
+  tokens: vi.fn(),
+  assets: vi.fn(),
+  refresh: vi.fn(),
+  client: {},
 }));
-vi.mock('farcaster-client-hooks', () => ({
-  useWalletPositionsQuery: mocks.query,
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => mocks.client,
 }));
-vi.mock('~/hooks/data/useIsSignedIn', () => ({
-  useIsSignedIn: mocks.signedIn,
+vi.mock('~/hooks/useLifiWallet', () => ({
+  useLifiWalletTokens: mocks.tokens,
+  useLifiAssets: mocks.assets,
+  refreshLifiWallet: mocks.refresh,
 }));
 vi.mock('~/components/forms/buttons/DefaultButton', () => ({
   DefaultButton: ({
@@ -29,204 +31,202 @@ vi.mock('~/components/forms/buttons/DefaultButton', () => ({
     </button>
   ),
 }));
-
-const address = '0x1111111111111111111111111111111111111111';
-const otherAddress = '0x2222222222222222222222222222222222222222';
-const position = (overrides: Partial<ApiEthFungibleTokenPosition> = {}) =>
-  ({
-    id: 'token',
-    chain: 'base',
-    symbol: 'TEST',
-    address,
-    decimals: 6,
-    quantity: { int: '1000000', float: 1 },
-    value: 2,
-    ...overrides,
-  }) as ApiEthFungibleTokenPosition;
-const result = (positions: ApiEthFungibleTokenPosition[]) => ({
-  data: { positions },
+const wallet = '0x1111111111111111111111111111111111111111';
+const token = {
+  chainId: 8453,
+  address: '0x2222222222222222222222222222222222222222',
+  symbol: 'TOKEN',
+  name: 'Token',
+  decimals: 6,
+  priceUSD: 2,
+  verificationStatus: 'verified',
+};
+const result = (tokens = [token]) => ({
+  data: { tokens },
   isPending: false,
   isError: false,
   isFetching: false,
-  refetch: mocks.refetch,
 });
-
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.signedIn.mockReturnValue(true);
-  mocks.query.mockReturnValue(result([position()]));
+  mocks.tokens.mockReturnValue(result());
+  mocks.assets.mockImplementation((_wallet, addresses: string[]) =>
+    addresses.map((address) => ({
+      data: { ...token, address, balance: 1000000n },
+      isError: false,
+      isFetching: false,
+    })),
+  );
 });
 afterEach(cleanup);
-
-describe('ExternalWalletPortfolio', () => {
-  it('excludes native ETH from rows and hidden-token counts, but keeps WETH', () => {
-    mocks.query.mockReturnValue(
-      result([
-        position({
-          id: 'native',
-          symbol: 'ETH',
-          address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-          hidden: true,
-        }),
-        position({
-          id: 'wrapped',
-          symbol: 'WETH',
-          address: '0x4200000000000000000000000000000000000006',
-          hidden: true,
-        }),
-      ]),
-    );
-    render(<ExternalWalletPortfolio address={address} />);
-    fireEvent.click(
-      screen.getByRole('checkbox', { name: 'Show hidden tokens (1)' }),
-    );
-    expect(screen.queryByText('ETH', { exact: true })).toBeNull();
-    expect(screen.getByText('WETH')).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(1);
-  });
-
-  it('shows a clear empty-token state for an ETH-only wallet', () => {
-    mocks.query.mockReturnValue(
-      result([
-        position({
-          symbol: 'ETH',
-          address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        }),
-      ]),
-    );
-    render(<ExternalWalletPortfolio address={address} />);
+describe('LI.FI portfolio', () => {
+  it('shows an accessible spinner before discovery without a misleading empty state', () => {
+    mocks.tokens.mockReturnValue({ isPending: true, isFetching: true });
+    render(<ExternalWalletPortfolio address={wallet} />);
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('Loading Base tokens');
     expect(
-      screen.getByText(
-        'No Base token holdings to show. Native ETH is shown above.',
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByRole('listitem')).toBeNull();
-    expect(screen.queryByRole('checkbox')).toBeNull();
-  });
-
-  it('requests holdings by connected address without previous-account placeholders', () => {
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(mocks.query).toHaveBeenCalledWith(
-      expect.objectContaining({
-        params: { address },
-        enabled: true,
-        keepPreviousData: false,
-      }),
+      status.querySelector('svg')?.classList.contains('animate-spin'),
+    ).toBe(true);
+    expect(status.querySelector('svg')?.getAttribute('aria-hidden')).toBe(
+      'true',
     );
-    expect(screen.getByText('TEST')).toBeTruthy();
+    expect(
+      status
+        .querySelector('svg')
+        ?.classList.contains('motion-reduce:animate-none'),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole('region', { name: 'Base token portfolio' })
+        .getAttribute('aria-busy'),
+    ).toBe('true');
+    expect(
+      (screen.getByRole('button', { name: 'Refreshing…' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(screen.queryByText(/No non-zero/)).toBeNull();
+  });
+  it('keeps a loading indicator until discovered token balances are available', () => {
+    mocks.assets.mockReturnValue([{ isFetching: true }]);
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByRole('status').textContent).toContain(
+      'Checking token balances',
+    );
+    expect(screen.getByText('Checking balance…')).toBeTruthy();
+    expect(screen.queryByText('$2.00')).toBeNull();
+    expect(screen.queryByText(/No non-zero/)).toBeNull();
+  });
+  it('replaces the loading state with token rows when balances arrive', () => {
+    mocks.tokens.mockReturnValue({ isPending: true, isFetching: true });
+    const view = render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByRole('status')).toBeTruthy();
+    mocks.tokens.mockReturnValue(result());
+    view.rerender(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(
+      screen
+        .getByRole('region', { name: 'Base token portfolio' })
+        .getAttribute('aria-busy'),
+    ).toBe('false');
     expect(screen.getByText('$2.00')).toBeTruthy();
   });
-
-  it('excludes other networks and reveals hidden tokens only when selected', () => {
-    mocks.query.mockReturnValue(
-      result([
-        position(),
-        position({ id: 'hidden', symbol: 'HIDDEN', hidden: true }),
-        position({ id: 'other', symbol: 'OTHER-CHAIN', chain: 'ethereum' }),
-      ]),
+  it('keeps existing balances visible while refreshing and prevents duplicate refresh clicks', () => {
+    mocks.tokens.mockReturnValue({ ...result(), isFetching: true });
+    render(<ExternalWalletPortfolio address={wallet} />);
+    const button = screen.getByRole('button', { name: 'Refreshing…' });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      button.querySelector('svg')?.classList.contains('animate-spin'),
+    ).toBe(true);
+    expect(screen.getByText('$2.00')).toBeTruthy();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByRole('status').textContent).toContain(
+      'Updating token balances',
     );
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(screen.queryByText('HIDDEN')).toBeNull();
-    fireEvent.click(screen.getByRole('checkbox'));
-    expect(screen.getByText('HIDDEN')).toBeTruthy();
-    expect(screen.queryByText('OTHER-CHAIN')).toBeNull();
+    fireEvent.click(button);
+    expect(mocks.refresh).not.toHaveBeenCalled();
   });
-
-  it('shows a loading state when there is no data yet', () => {
-    mocks.query.mockReturnValue({
-      ...result([]),
-      data: undefined,
-      isPending: true,
-      isFetching: true,
-    });
-    render(<ExternalWalletPortfolio address={address} />);
+  it('shows an error rather than spinning indefinitely after discovery fails', () => {
+    mocks.tokens.mockReturnValue({ isPending: true, isError: true });
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Refresh tokens',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
+  it('keeps the data-source explanation in a collapsed disclosure', () => {
+    render(<ExternalWalletPortfolio address={wallet} />);
+    const details = screen.getByText('About these balances').closest('details');
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain(
+      'Token discovery and estimated prices by LI.FI',
+    );
+    expect(details?.textContent).toContain('Native ETH is shown above');
+  });
+  it('uses the connected wallet without requiring Farcaster authentication', () => {
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(mocks.tokens).toHaveBeenCalledWith(wallet);
+    expect(mocks.assets).toHaveBeenCalledWith(wallet, [token.address]);
+    expect(screen.getByText('$2.00')).toBeTruthy();
+    expect(screen.getByText('1')).toBeTruthy();
+  });
+  it('does not duplicate native ETH in token rows', () => {
+    mocks.tokens.mockReturnValue(
+      result([{ ...token, address: zeroAddress, symbol: 'ETH' }, token]),
+    );
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.queryByText('ETH', { exact: true })).toBeNull();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+  it('hides verified zero balances even if the indexed API listed the token', () => {
+    mocks.assets.mockReturnValue([
+      { data: { ...token, balance: 0n }, isError: false },
+    ]);
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.queryByRole('listitem')).toBeNull();
+    expect(screen.getByText(/No non-zero Base/)).toBeTruthy();
+  });
+  it('does not turn a failed balance read into zero or show an old valuation', () => {
+    mocks.assets.mockReturnValue([
+      { data: { ...token, balance: 1000000n }, isError: true },
+    ]);
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByText('Balance unavailable')).toBeTruthy();
+    expect(screen.queryByText('$2.00')).toBeNull();
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+  it('separates unverified tokens and warns when revealed', () => {
+    mocks.tokens.mockReturnValue(
+      result([{ ...token, verificationStatus: 'unknown' }]),
+    );
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.queryByRole('listitem')).toBeNull();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(screen.getByText('TOKEN')).toBeTruthy();
+    expect(screen.getByText(/may include spam/)).toBeTruthy();
+  });
+  it('shows discovery failures separately from an empty portfolio', () => {
+    mocks.tokens.mockReturnValue({ isError: true });
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByRole('alert').textContent).toContain('LI.FI');
+    expect(screen.queryByText(/No non-zero/)).toBeNull();
+  });
+  it('shows discovery loading', () => {
+    mocks.tokens.mockReturnValue({ isPending: true });
+    render(<ExternalWalletPortfolio address={wallet} />);
     expect(screen.getByRole('status').textContent).toContain('Loading');
   });
-
-  it('shows an empty state and refreshes on request', () => {
-    mocks.query.mockReturnValue(result([]));
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(
-      screen.getByText(
-        'No Base token holdings to show. Native ETH is shown above.',
-      ),
-    ).toBeTruthy();
+  it('refreshes the shared wallet cache', () => {
+    render(<ExternalWalletPortfolio address={wallet} />);
     fireEvent.click(screen.getByRole('button', { name: 'Refresh tokens' }));
-    expect(mocks.refetch).toHaveBeenCalledTimes(1);
+    expect(mocks.refresh).toHaveBeenCalledWith(mocks.client, wallet);
   });
-
-  it('distinguishes a failed lookup from an empty portfolio', () => {
-    mocks.query.mockReturnValue({
-      ...result([]),
-      data: undefined,
-      isError: true,
+  it('warns when discovery is partial', () => {
+    mocks.tokens.mockReturnValue({
+      ...result(),
+      data: { tokens: [token], skipped: 1 },
     });
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(screen.getByRole('alert').textContent).toContain('Could not load');
-    expect(
-      screen.queryByText(
-        'No Base token holdings to show. Native ETH is shown above.',
-      ),
-    ).toBeNull();
+    render(<ExternalWalletPortfolio address={wallet} />);
+    expect(screen.getByText(/partial token list/)).toBeTruthy();
   });
-
-  it('warns when cached balances could not be refreshed', () => {
-    mocks.query.mockReturnValue({ ...result([position()]), isError: true });
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(screen.getByRole('alert').textContent).toContain('out of date');
-    expect(screen.getByText('TEST')).toBeTruthy();
-  });
-
-  it('does not fetch or display cached holdings when signed out', () => {
-    mocks.signedIn.mockReturnValue(false);
-    render(<ExternalWalletPortfolio address={address} />);
-    expect(mocks.query).toHaveBeenCalledWith(
-      expect.objectContaining({ enabled: false }),
-    );
-    expect(screen.queryByText('TEST')).toBeNull();
-  });
-
-  it('changes the query address and clears the old view when switching wallets', () => {
-    const { rerender } = render(
-      <ExternalWalletPortfolio key={address} address={address} />,
-    );
-    mocks.query.mockReturnValue({
-      ...result([]),
-      data: undefined,
-      isPending: true,
-    });
-    rerender(
-      <ExternalWalletPortfolio key={otherAddress} address={otherAddress} />,
-    );
-    expect(mocks.query).toHaveBeenLastCalledWith(
-      expect.objectContaining({ params: { address: otherAddress } }),
-    );
-    expect(screen.queryByText('TEST')).toBeNull();
-  });
-
-  it('treats token claim links as plain untrusted text', () => {
-    mocks.query.mockReturnValue(
-      result([position({ symbol: 'Claim https://example.invalid' })]),
-    );
-    render(<ExternalWalletPortfolio address={address} />);
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(1);
-    expect(links[0].getAttribute('href')).toBe(
-      `https://basescan.org/token/${address}`,
-    );
-  });
-
-  it('limits long lists until the user requests more tokens', () => {
-    mocks.query.mockReturnValue(
+  it('loads at most 20 rows before show more', () => {
+    mocks.tokens.mockReturnValue(
       result(
-        Array.from({ length: 25 }, (_, i) =>
-          position({ id: String(i), symbol: `TOKEN-${i}` }),
-        ),
+        Array.from({ length: 21 }, (_, i) => ({
+          ...token,
+          address: `0x${(i + 1).toString(16).padStart(40, '0')}`,
+        })),
       ),
     );
-    render(<ExternalWalletPortfolio address={address} />);
+    render(<ExternalWalletPortfolio address={wallet} />);
     expect(screen.getAllByRole('listitem')).toHaveLength(20);
-    fireEvent.click(screen.getByRole('button', { name: /Show more tokens/ }));
-    expect(screen.getAllByRole('listitem')).toHaveLength(25);
+    fireEvent.click(screen.getByRole('button', { name: /Show more/ }));
+    expect(screen.getAllByRole('listitem')).toHaveLength(21);
   });
 });

--- a/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletSend.test.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletSend.test.tsx
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExternalWalletSend } from '~/components/rightSidebar/ExternalWalletSend';
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+  submit: vi.fn(),
+  receipt: vi.fn(),
+  invalidate: vi.fn(),
+  asset: vi.fn(),
+  refetch: vi.fn(),
+  reader: { nativeBalance: vi.fn(), tokenDetails: vi.fn() },
+  client: {},
+  provider: { request: vi.fn() },
+}));
+const address = '0x1111111111111111111111111111111111111111';
+const recipient = '0x2222222222222222222222222222222222222222';
+const tokenAddress = '0x3333333333333333333333333333333333333333';
+const hash = `0x${'a'.repeat(64)}`;
+const prepared = {
+  input: { address, recipient, amount: '1.25', tokenAddress },
+  call: { account: address, to: tokenAddress, value: 0n },
+  units: 1_250_000n,
+  decimals: 6,
+  symbol: 'TOKEN',
+  balance: 5_000_000n,
+  estimatedFee: 1_000_000_000_000n,
+  preparedAt: 0,
+};
+
+vi.mock('~/contexts/WalletProvider', () => ({
+  useWallet: () => ({ provider: mocks.provider }),
+}));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidate }),
+}));
+vi.mock('wagmi', () => ({
+  usePublicClient: () => mocks.client,
+  useWaitForTransactionReceipt: mocks.receipt,
+}));
+vi.mock('~/hooks/useLifiWallet', () => ({
+  useLifiTransferReader: () => mocks.reader,
+  useLifiAsset: mocks.asset,
+  refreshLifiWallet: mocks.invalidate,
+  useLifiWalletTokens: () => ({
+    data: {
+      tokens: [
+        {
+          address: tokenAddress,
+          symbol: 'TOKEN',
+          chainId: 8453,
+          verificationStatus: 'verified',
+        },
+      ],
+    },
+    isError: false,
+    isPending: false,
+  }),
+}));
+vi.mock('~/utils/baseWalletTransfer', () => ({
+  createBaseTransferReader: () => mocks.reader,
+  prepareBaseTransfer: mocks.prepare,
+  submitBaseTransfer: mocks.submit,
+}));
+vi.mock('~/components/forms/buttons/DefaultButton', () => ({
+  DefaultButton: ({
+    children,
+    disabled,
+    type,
+    onClick,
+  }: React.ComponentProps<'button'>) => (
+    <button type={type} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.asset.mockImplementation((_wallet: string, token: string) => ({
+    data:
+      token === tokenAddress
+        ? { symbol: 'TOKEN', decimals: 6, balance: 5000001n }
+        : { symbol: 'ETH', decimals: 18, balance: 1230000000000000000n },
+    isError: false,
+    isFetching: false,
+    refetch: mocks.refetch,
+  }));
+  mocks.reader.nativeBalance
+    .mockReset()
+    .mockResolvedValue(1230000000000000000n);
+  mocks.reader.tokenDetails
+    .mockReset()
+    .mockResolvedValue({ symbol: 'TOKEN', decimals: 6, balance: 5000001n });
+  mocks.prepare.mockResolvedValue(prepared);
+  mocks.submit.mockResolvedValue(hash);
+  mocks.receipt.mockReturnValue({ data: undefined, isError: false });
+});
+afterEach(cleanup);
+
+async function review() {
+  fireEvent.change(screen.getByLabelText('Asset'), {
+    target: { value: tokenAddress },
+  });
+  fireEvent.change(screen.getByLabelText('Recipient'), {
+    target: { value: recipient },
+  });
+  fireEvent.change(screen.getByLabelText('Amount'), {
+    target: { value: '1.25' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Review send' }));
+  await screen.findByRole('button', { name: 'Confirm in wallet' });
+}
+
+describe('ExternalWalletSend', () => {
+  it('shows the native balance before entering an amount', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await screen.findByText('Available on Base: 1.23 ETH');
+    expect(mocks.asset).toHaveBeenCalledWith(
+      address,
+      '0x0000000000000000000000000000000000000000',
+    );
+    expect(mocks.prepare).not.toHaveBeenCalled();
+    expect(mocks.submit).not.toHaveBeenCalled();
+  });
+  it('shows the selected token balance with exact decimals', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await screen.findByText('Available on Base: 1.23 ETH');
+    fireEvent.change(screen.getByLabelText('Asset'), {
+      target: { value: tokenAddress },
+    });
+    expect(screen.queryByText('Available on Base: 1.23 ETH')).toBeNull();
+    await screen.findByText('Available on Base: 5.000001 TOKEN');
+    expect(mocks.asset).toHaveBeenCalledWith(address, tokenAddress);
+  });
+  it('shows balance errors as unavailable and offers a shared refresh', async () => {
+    mocks.asset.mockReturnValue({ isError: true, refetch: mocks.refetch });
+    render(<ExternalWalletSend address={address} />);
+    await screen.findByText('Could not load balance on Base. Try refreshing.');
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh balance' }));
+    expect(mocks.refetch).toHaveBeenCalledOnce();
+  });
+  it('shows a loading state while the shared cache reads a balance', () => {
+    mocks.asset.mockReturnValue({ isError: false, data: undefined });
+    render(<ExternalWalletSend address={address} />);
+    expect(screen.getByText('Loading balance on Base…')).toBeTruthy();
+  });
+  it('does not retain the previous account balance after changing accounts', async () => {
+    const { rerender } = render(<ExternalWalletSend address={address} />);
+    await screen.findByText('Available on Base: 1.23 ETH');
+    mocks.asset.mockReturnValue({
+      data: { symbol: 'ETH', decimals: 18, balance: 0n },
+    });
+    rerender(<ExternalWalletSend address={recipient} />);
+    expect(screen.queryByText('Available on Base: 1.23 ETH')).toBeNull();
+    await screen.findByText('Available on Base: 0 ETH');
+    expect(mocks.asset).toHaveBeenLastCalledWith(
+      recipient,
+      '0x0000000000000000000000000000000000000000',
+    );
+  });
+  it('prepares the selected token read-only before offering wallet confirmation', async () => {
+    render(<ExternalWalletSend address={address} />);
+    expect(
+      screen.queryByRole('button', { name: 'Confirm in wallet' }),
+    ).toBeNull();
+    await review();
+    expect(mocks.prepare).toHaveBeenCalledWith(mocks.reader, {
+      address,
+      recipient,
+      amount: '1.25',
+      tokenAddress,
+    });
+    expect(mocks.submit).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('region', { name: 'Review Base transfer' }).textContent,
+    ).toContain('1.25 TOKEN');
+  });
+  it('invalidates the review after editing an amount', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '2' },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Confirm in wallet' }),
+    ).toBeNull();
+  });
+  it('shows live-check failures without offering confirmation', async () => {
+    mocks.prepare.mockRejectedValue(new Error('Insufficient TOKEN balance.'));
+    render(<ExternalWalletSend address={address} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Review send' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Insufficient',
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Confirm in wallet' }),
+    ).toBeNull();
+  });
+  it('handles wallet rejection without claiming submission', async () => {
+    mocks.submit.mockRejectedValue(new Error('User rejected request'));
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm in wallet' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'rejected',
+    );
+    expect(
+      screen.queryByRole('link', { name: 'View transaction on BaseScan' }),
+    ).toBeNull();
+  });
+  it('does not send twice when confirmation is clicked repeatedly', async () => {
+    let resolve!: (hash: string) => void;
+    mocks.submit.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    const button = screen.getByRole('button', { name: 'Confirm in wallet' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(mocks.submit).toHaveBeenCalledTimes(1);
+    await act(async () => resolve(hash));
+  });
+  it('does not claim confirmation just because a hash was returned', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm in wallet' }));
+    expect((await screen.findByRole('status')).textContent).toContain(
+      'Waiting for confirmation',
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toBe(
+      `https://basescan.org/tx/${hash}`,
+    );
+  });
+  it.each([
+    ['success', 'Transaction confirmed on Base.'],
+    ['reverted', 'Transaction reverted on Base.'],
+  ])('reports receipt status %s accurately', async (status, message) => {
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    mocks.receipt.mockReturnValue({
+      data: { status, transactionHash: hash },
+      isError: false,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm in wallet' }));
+    await waitFor(() =>
+      expect(screen.getByRole('status').textContent).toContain(message),
+    );
+  });
+  it('reports unavailable confirmation without labelling the transfer failed', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    mocks.receipt.mockReturnValue({ data: undefined, isError: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm in wallet' }));
+    expect((await screen.findByRole('status')).textContent).toContain(
+      'Confirmation unavailable',
+    );
+  });
+  it('does not label a cancellation receipt as a confirmed transfer', async () => {
+    render(<ExternalWalletSend address={address} />);
+    await review();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm in wallet' }));
+    await screen.findByRole('status');
+    mocks.receipt.mockReturnValue({
+      data: { status: 'success', transactionHash: hash },
+      isError: false,
+    });
+    act(() =>
+      mocks.receipt.mock.lastCall?.[0].onReplaced({ reason: 'cancelled' }),
+    );
+    expect(screen.getByRole('status').textContent).toContain(
+      'Transaction cancelled.',
+    );
+  });
+  it('ignores an old preparation result after changing accounts', async () => {
+    let resolve!: (value: typeof prepared) => void;
+    mocks.prepare.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const { rerender } = render(
+      <ExternalWalletSend key={address} address={address} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Review send' }));
+    rerender(<ExternalWalletSend key={recipient} address={recipient} />);
+    await act(async () => resolve(prepared));
+    expect(
+      screen.queryByRole('button', { name: 'Confirm in wallet' }),
+    ).toBeNull();
+  });
+});

--- a/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletSwap.test.tsx
+++ b/apps/farcaster-web/src/components/rightSidebar/__tests__/ExternalWalletSwap.test.tsx
@@ -1,0 +1,954 @@
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import { decodeFunctionData, erc20Abi, zeroAddress } from 'viem';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExternalWalletSwap } from '~/components/rightSidebar/ExternalWalletSwap';
+
+const mocks = vi.hoisted(() => ({
+  fresh: vi.fn(),
+  asset: vi.fn(),
+  quote: vi.fn(),
+  request: vi.fn(),
+  guard: vi.fn(),
+  receipt: vi.fn(),
+  refresh: vi.fn(),
+  tokens: vi.fn(),
+  refetchTokens: vi.fn(),
+  readContract: vi.fn(),
+  wait: vi.fn(),
+  queryClient: {},
+  walletAddress: '0x1111111111111111111111111111111111111111',
+}));
+const wallet = '0x1111111111111111111111111111111111111111';
+const contract = '0x2222222222222222222222222222222222222222';
+const hash = `0x${'a'.repeat(64)}`;
+const from = {
+  chainId: 8453,
+  address: zeroAddress,
+  symbol: 'ETH',
+  name: 'Ether',
+  decimals: 18,
+  balance: 1000000000000000000n,
+};
+const to = {
+  ...from,
+  address: contract,
+  symbol: 'TOKEN',
+  decimals: 6,
+  balance: 0n,
+};
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => mocks.queryClient,
+}));
+const provider = { request: mocks.request };
+vi.mock('~/contexts/WalletProvider', () => ({
+  useWallet: () => ({ address: mocks.walletAddress, provider }),
+}));
+vi.mock('wagmi', () => ({
+  usePublicClient: () => ({
+    readContract: mocks.readContract,
+    waitForTransactionReceipt: mocks.wait,
+  }),
+  useWaitForTransactionReceipt: mocks.receipt,
+}));
+vi.mock('~/hooks/useLifiWallet', () => ({
+  useLifiAsset: mocks.asset,
+  fetchFreshLifiAsset: mocks.fresh,
+  refreshLifiWallet: mocks.refresh,
+  useLifiWalletTokens: mocks.tokens,
+}));
+vi.mock('~/utils/lifiSwap', () => ({ fetchLifiQuote: mocks.quote }));
+vi.mock('~/utils/sendBaseNativeToken', () => ({
+  ensureBaseWalletAccount: mocks.guard,
+}));
+vi.mock('~/components/forms/buttons/DefaultButton', () => ({
+  DefaultButton: ({
+    children,
+    onClick,
+    type,
+    disabled,
+  }: React.ComponentProps<'button'>) => (
+    <button onClick={onClick} type={type} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.walletAddress = wallet;
+  mocks.tokens.mockReturnValue({
+    data: { tokens: [] },
+    refetch: mocks.refetchTokens,
+  });
+  mocks.asset.mockImplementation((_wallet, token) => ({
+    data: token === zeroAddress ? from : token === contract ? to : undefined,
+    isError: false,
+  }));
+  mocks.fresh.mockImplementation((_cache, _client, _wallet, token) =>
+    Promise.resolve(token === zeroAddress ? from : to),
+  );
+  mocks.quote.mockResolvedValue({
+    tool: 'test',
+    action: { fromAmount: '1000000000000' },
+    estimate: { toAmount: '1000', toAmountMin: '990' },
+    transactionRequest: { to: contract, data: '0xabcd', value: '0xe8d4a51000' },
+  });
+  mocks.request.mockReset().mockResolvedValue(hash);
+  mocks.guard.mockResolvedValue(undefined);
+  mocks.receipt.mockReturnValue({ data: undefined, isError: false });
+  mocks.readContract.mockReset().mockResolvedValue(0n);
+  mocks.wait
+    .mockReset()
+    .mockResolvedValue({ status: 'success', blockNumber: 123n });
+});
+afterEach(cleanup);
+
+const wethAddress = '0x4200000000000000000000000000000000000006';
+const spender = '0x3333333333333333333333333333333333333333';
+const wethUnits = 250000000000000000n;
+const weth = {
+  ...from,
+  address: wethAddress,
+  symbol: 'WETH',
+  name: 'Wrapped Ether',
+  balance: 2000000000000000000n,
+  verificationStatus: 'verified',
+};
+const wethRoute = {
+  tool: 'test',
+  estimate: {
+    toAmount: '249000000000000000',
+    toAmountMin: '247000000000000000',
+    approvalAddress: spender,
+  },
+  transactionRequest: { to: spender, data: '0xabcd', value: '0x0' },
+};
+function setupWeth() {
+  mocks.tokens.mockReturnValue({
+    data: { tokens: [weth, { ...to, verificationStatus: 'verified' }] },
+    refetch: mocks.refetchTokens,
+  });
+  mocks.asset.mockImplementation((_wallet, token) => ({
+    data: token === wethAddress ? weth : token === zeroAddress ? from : to,
+    isError: false,
+  }));
+  mocks.fresh.mockImplementation((_cache, _client, _wallet, token) =>
+    Promise.resolve(
+      token === wethAddress ? weth : token === zeroAddress ? from : to,
+    ),
+  );
+  mocks.quote.mockResolvedValue(wethRoute);
+}
+async function quoteWeth() {
+  fireEvent.change(screen.getByLabelText('Choose sell asset'), {
+    target: { value: wethAddress },
+  });
+  fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+    target: { value: 'ETH' },
+  });
+  fireEvent.change(screen.getByLabelText('Amount'), {
+    target: { value: '0.25' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+  await screen.findByRole('button', { name: /Approve WETH|Review swap/ });
+}
+
+describe('WETH approval sequencing', () => {
+  it('waits for the approval block to become readable without repeating approval or sending the swap', async () => {
+    setupWeth();
+    mocks.readContract
+      .mockResolvedValueOnce(0n)
+      .mockResolvedValueOnce(0n)
+      .mockRejectedValueOnce(new Error('block not found: 0x7b'))
+      .mockResolvedValue(wethUnits);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+      });
+      expect(screen.getByRole('status').textContent).toContain(
+        'Waiting for Base RPC to catch up',
+      );
+      expect(mocks.request).toHaveBeenCalledOnce();
+      expect(mocks.wait).toHaveBeenCalledOnce();
+      expect(screen.queryByRole('button', { name: 'Review swap' })).toBeNull();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+      expect(screen.getByRole('button', { name: 'Review swap' })).toBeTruthy();
+      expect(mocks.request).toHaveBeenCalledOnce();
+      expect(mocks.wait).toHaveBeenCalledOnce();
+      expect(
+        mocks.readContract.mock.calls
+          .slice(-2)
+          .map(([call]) => call.blockNumber),
+      ).toEqual([123n, 123n]);
+      expect(screen.queryByRole('alert')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it('shows the approved amount, required amount and exact Base spender before approval', async () => {
+    setupWeth();
+    mocks.readContract.mockResolvedValue(100000000000000000n);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    const details = screen.getByLabelText('Token approval').textContent;
+    expect(details).toContain('Approved: 0.1 WETH');
+    expect(details).toContain('Required: 0.25 WETH');
+    expect(details).toContain(`Base spender: ${spender}`);
+    expect(screen.getByRole('button', { name: 'Approve WETH' })).toBeTruthy();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('reads the confirmed approval block even if latest allowance is stale', async () => {
+    setupWeth();
+    mocks.readContract.mockImplementation(({ blockNumber }) =>
+      Promise.resolve(blockNumber === 123n ? wethUnits : 0n),
+    );
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    await screen.findByRole('button', { name: 'Review swap' });
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(mocks.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ blockNumber: 123n }),
+    );
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain(
+      'Approval confirmed',
+    );
+  });
+  it('does not silently send approval when allowance falls before a Review swap click', async () => {
+    setupWeth();
+    mocks.readContract.mockResolvedValueOnce(wethUnits).mockResolvedValue(0n);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await screen.findByRole('button', { name: 'Approve WETH' });
+    expect(mocks.request).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Token approval').textContent).toContain(
+      'Approved: 0 WETH',
+    );
+    expect(screen.getByRole('status').textContent).toContain(
+      'Allowance changed',
+    );
+  });
+  it('does not silently swap when allowance grows before an Approve click', async () => {
+    setupWeth();
+    mocks.readContract.mockResolvedValueOnce(0n).mockResolvedValue(wethUnits);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    await screen.findByRole('button', { name: 'Review swap' });
+    expect(mocks.request).not.toHaveBeenCalled();
+    expect(mocks.wait).not.toHaveBeenCalled();
+    expect(screen.getByRole('status').textContent).toContain(
+      'Already approved',
+    );
+  });
+  it('blocks trading if allowance cannot be read instead of assuming zero or approval', async () => {
+    setupWeth();
+    mocks.readContract.mockRejectedValue(new Error('Allowance unavailable'));
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose sell asset'), {
+      target: { value: wethAddress },
+    });
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: 'ETH' },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.25' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Allowance unavailable',
+    );
+    expect(
+      screen.queryByRole('button', { name: /Approve WETH|Review swap/ }),
+    ).toBeNull();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('rechecks approval for the new spender when requesting another quote', async () => {
+    setupWeth();
+    mocks.readContract.mockImplementation(({ args }) =>
+      Promise.resolve(args[1] === spender ? wethUnits : 0n),
+    );
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    expect(screen.getByRole('button', { name: 'Review swap' })).toBeTruthy();
+    mocks.quote.mockResolvedValue({
+      ...wethRoute,
+      estimate: { ...wethRoute.estimate, approvalAddress: contract },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.2' },
+    });
+    expect(screen.queryByLabelText('Token approval')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    await screen.findByRole('button', { name: 'Approve WETH' });
+    expect(screen.getByLabelText('Token approval').textContent).toContain(
+      `Base spender: ${contract}`,
+    );
+    expect(mocks.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ args: [wallet, contract] }),
+    );
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('waits for the approval receipt, then rechecks allowance before requesting the swap', async () => {
+    setupWeth();
+    let confirmApproval!: (receipt: {
+      status: string;
+      blockNumber: bigint;
+    }) => void;
+    mocks.wait.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          confirmApproval = resolve;
+        }),
+    );
+    mocks.readContract
+      .mockResolvedValueOnce(0n)
+      .mockResolvedValueOnce(0n)
+      .mockResolvedValue(wethUnits);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    // Getting the quote itself must never ask the wallet for approval.
+    expect(mocks.request).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    await waitFor(() => expect(mocks.wait).toHaveBeenCalledWith({ hash }));
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+    const approval = mocks.request.mock.calls[0][0].params[0];
+    expect(approval).toMatchObject({
+      chainId: '0x2105',
+      from: wallet,
+      to: wethAddress,
+    });
+    expect(decodeFunctionData({ abi: erc20Abi, data: approval.data })).toEqual({
+      functionName: 'approve',
+      args: [spender, wethUnits],
+    });
+    expect(screen.getByRole('status').textContent).toContain(
+      'Waiting for token approval',
+    );
+    expect(mocks.readContract).toHaveBeenCalledTimes(2);
+    expect(
+      (screen.getByLabelText('Choose sell asset') as HTMLSelectElement).closest(
+        'fieldset',
+      )?.disabled,
+    ).toBe(true);
+    await act(async () =>
+      confirmApproval({ status: 'success', blockNumber: 123n }),
+    );
+    await screen.findByRole('button', { name: 'Review swap' });
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(screen.getByLabelText('Token approval').textContent).toContain(
+      'Approved: 0.25 WETH',
+    );
+    expect(mocks.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        blockNumber: 123n,
+        address: wethAddress,
+        functionName: 'allowance',
+        args: [wallet, spender],
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledTimes(2));
+    expect(mocks.request.mock.calls[1][0].params[0]).toMatchObject({
+      chainId: '0x2105',
+      from: wallet,
+      to: spender,
+      data: '0xabcd',
+    });
+    expect(mocks.readContract.mock.invocationCallOrder[3]).toBeLessThan(
+      mocks.request.mock.invocationCallOrder[1],
+    );
+  });
+  it.each([wethUnits, wethUnits + 1n])(
+    'skips approval when WETH allowance is already sufficient (%s)',
+    async (allowance) => {
+      setupWeth();
+      mocks.readContract.mockResolvedValue(allowance);
+      render(<ExternalWalletSwap />);
+      await quoteWeth();
+      fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+      await screen.findByRole('link');
+      expect(mocks.request).toHaveBeenCalledOnce();
+      expect(mocks.request.mock.calls[0][0].params[0].to).toBe(spender);
+      expect(mocks.wait).not.toHaveBeenCalled();
+    },
+  );
+  it('does not request a swap after approval is rejected in the wallet', async () => {
+    setupWeth();
+    mocks.request.mockRejectedValueOnce(new Error('Approval rejected by user'));
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Approval rejected',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(mocks.wait).not.toHaveBeenCalled();
+    expect(mocks.refresh).not.toHaveBeenCalled();
+  });
+  it('does not request a swap when approval confirmation times out', async () => {
+    setupWeth();
+    mocks.wait.mockRejectedValueOnce(
+      new Error('Approval confirmation timed out'),
+    );
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'timed out',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+  it('blocks the swap if a successful receipt did not establish sufficient allowance', async () => {
+    setupWeth();
+    mocks.readContract.mockResolvedValue(0n);
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'allowance is still insufficient',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+  });
+  it('requires a new review if the spender changes after approval', async () => {
+    setupWeth();
+    render(<ExternalWalletSwap />);
+    await quoteWeth();
+    mocks.quote.mockResolvedValueOnce(wethRoute).mockResolvedValueOnce({
+      ...wethRoute,
+      estimate: { ...wethRoute.estimate, approvalAddress: contract },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Quote changed',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(mocks.request.mock.calls[0][0].params[0].to).toBe(wethAddress);
+  });
+  it('stops after approval if the connected account changes while waiting', async () => {
+    setupWeth();
+    let confirmApproval!: (receipt: { status: string }) => void;
+    mocks.wait.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          confirmApproval = resolve;
+        }),
+    );
+    const view = render(<ExternalWalletSwap />);
+    await quoteWeth();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve WETH' }));
+    await waitFor(() => expect(mocks.wait).toHaveBeenCalledOnce());
+    mocks.walletAddress = contract;
+    view.rerender(<ExternalWalletSwap />);
+    await act(async () => confirmApproval({ status: 'success' }));
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(mocks.quote).toHaveBeenCalledTimes(2);
+  });
+  it('does not treat buying WETH with native ETH as spending WETH', async () => {
+    setupWeth();
+    mocks.quote.mockResolvedValue({
+      ...wethRoute,
+      transactionRequest: {
+        ...wethRoute.transactionRequest,
+        value: `0x${wethUnits.toString(16)}`,
+      },
+    });
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: wethAddress },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.25' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    await screen.findByRole('button', { name: 'Review swap' });
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await screen.findByRole('link');
+    expect(mocks.readContract).not.toHaveBeenCalled();
+    expect(mocks.wait).not.toHaveBeenCalled();
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(mocks.request.mock.calls[0][0].params[0].value).toBe(
+      `0x${wethUnits.toString(16)}`,
+    );
+  });
+});
+
+describe('trade selector regressions', () => {
+  const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+  function choices(label: string) {
+    return Array.from(
+      (screen.getByLabelText(label) as HTMLSelectElement).options,
+    );
+  }
+  it('offers only ETH and native Base USDC as defaults without wallet holdings', () => {
+    render(<ExternalWalletSwap />);
+    expect(choices('Choose buy asset').map((option) => option.value)).toEqual([
+      'ETH',
+      usdc,
+      'custom',
+    ]);
+    expect(choices('Choose sell asset').map((option) => option.value)).toEqual([
+      'ETH',
+      'custom',
+    ]);
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it.each([{ isPending: true }, { isError: true }])(
+    'keeps the defaults when discovery is unavailable: %j',
+    (state) => {
+      mocks.tokens.mockReturnValue({ ...state, refetch: mocks.refetchTokens });
+      render(<ExternalWalletSwap />);
+      expect(choices('Choose buy asset').map((option) => option.value)).toEqual(
+        ['ETH', usdc, 'custom'],
+      );
+    },
+  );
+  it('selects the canonical USDC contract and reads it through the shared balance hook', () => {
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: usdc },
+    });
+    expect((screen.getByLabelText('Buy token') as HTMLInputElement).value).toBe(
+      usdc,
+    );
+    expect(mocks.asset).toHaveBeenCalledWith(wallet, usdc);
+    expect(mocks.quote).not.toHaveBeenCalled();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('requests an ETH to native Base USDC quote through the existing quote flow', async () => {
+    const usdcAsset = {
+      ...to,
+      address: usdc,
+      symbol: 'USDC',
+      decimals: 6,
+      balance: 0n,
+    };
+    mocks.fresh.mockImplementation((_cache, _client, _wallet, token) =>
+      Promise.resolve(token === zeroAddress ? from : usdcAsset),
+    );
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: usdc },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.000001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    await screen.findByRole('button', { name: 'Review swap' });
+    expect(mocks.quote).toHaveBeenCalledWith(
+      wallet,
+      from,
+      usdcAsset,
+      1000000000000n,
+    );
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('deduplicates owned USDC by contract, irrespective of address casing or discovery label', () => {
+    mocks.tokens.mockReturnValue({
+      data: {
+        tokens: [
+          {
+            ...to,
+            address: usdc.toLowerCase(),
+            symbol: 'wrong label',
+            verificationStatus: 'unknown',
+          },
+        ],
+      },
+    });
+    render(<ExternalWalletSwap />);
+    expect(
+      choices('Choose buy asset').filter(
+        (option) => option.value.toLowerCase() === usdc.toLowerCase(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      choices('Choose sell asset').find((option) => option.value === usdc)
+        ?.textContent,
+    ).toContain('USDC — native USDC on Base');
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+  it('does not promote same-symbol tokens or bridged USDbC to the native USDC default', () => {
+    const bridged = '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA';
+    mocks.tokens.mockReturnValue({
+      data: {
+        tokens: [
+          {
+            ...to,
+            address: contract,
+            symbol: 'USDC',
+            verificationStatus: 'unknown',
+          },
+          {
+            ...to,
+            address: bridged,
+            symbol: 'USDbC',
+            verificationStatus: 'verified',
+          },
+          { ...to, address: usdc, chainId: 1, verificationStatus: 'verified' },
+        ],
+      },
+    });
+    render(<ExternalWalletSwap />);
+    expect(choices('Choose buy asset').map((option) => option.value)).toEqual([
+      'ETH',
+      usdc,
+      bridged,
+      'custom',
+    ]);
+    expect(
+      choices('Choose sell asset').some((option) => option.value === usdc),
+    ).toBe(false);
+    fireEvent.click(screen.getByRole('checkbox'));
+    const lookalike = choices('Choose buy asset').find(
+      (option) => option.value === contract,
+    );
+    expect(lookalike?.textContent).toContain('(unverified)');
+    expect(lookalike?.textContent).not.toContain('native USDC');
+  });
+  it('selects buy and sell contracts independently without opening the wallet', () => {
+    setupWeth();
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose sell asset'), {
+      target: { value: wethAddress },
+    });
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: contract },
+    });
+    expect(
+      (screen.getByLabelText('Sell token') as HTMLInputElement).value,
+    ).toBe(wethAddress);
+    expect((screen.getByLabelText('Buy token') as HTMLInputElement).value).toBe(
+      contract,
+    );
+    expect(mocks.quote).not.toHaveBeenCalled();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('never silently switches an unverified selected contract to ETH when its list entry is hidden', () => {
+    mocks.tokens.mockReturnValue({
+      data: { tokens: [{ ...to, verificationStatus: 'unknown' }] },
+      refetch: mocks.refetchTokens,
+    });
+    render(<ExternalWalletSwap />);
+    const toggle = screen.getByRole('checkbox');
+    fireEvent.click(toggle);
+    fireEvent.change(screen.getByLabelText('Choose sell asset'), {
+      target: { value: contract },
+    });
+    fireEvent.click(toggle);
+    expect(
+      (screen.getByLabelText('Sell token') as HTMLInputElement).value,
+    ).toBe(contract);
+    expect(
+      (screen.getByLabelText('Choose sell asset') as HTMLSelectElement).value,
+    ).toBe('custom');
+    expect(mocks.asset.mock.calls.slice(-2)).toEqual([
+      [wallet, contract],
+      [wallet, undefined],
+    ]);
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('ignores a late quote after account changes', async () => {
+    let complete!: (quote: typeof wethRoute) => void;
+    setupWeth();
+    mocks.quote.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const view = render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText('Choose buy asset'), {
+      target: { value: wethAddress },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.25' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    await waitFor(() => expect(mocks.quote).toHaveBeenCalledOnce());
+    mocks.walletAddress = contract;
+    view.rerender(<ExternalWalletSwap />);
+    await act(async () => complete(wethRoute));
+    expect(screen.queryByRole('button', { name: 'Review swap' })).toBeNull();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+});
+async function getQuote() {
+  fireEvent.change(screen.getByLabelText(/Buy token/), {
+    target: { value: contract },
+  });
+  fireEvent.change(screen.getByLabelText('Amount'), {
+    target: { value: '0.000001' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+  await screen.findByRole('button', { name: 'Review swap' });
+}
+describe('LI.FI swap balance integration', () => {
+  it('lists all verified wallet tokens even when ETH is already entered', () => {
+    mocks.tokens.mockReturnValue({
+      data: {
+        tokens: [
+          { ...from, verificationStatus: 'verified' },
+          { ...to, verificationStatus: 'verified' },
+          {
+            ...to,
+            address: '0x4200000000000000000000000000000000000006',
+            symbol: 'WETH',
+            verificationStatus: 'verified',
+          },
+        ],
+      },
+      refetch: mocks.refetchTokens,
+    });
+    render(<ExternalWalletSwap />);
+    const sell = screen.getByLabelText(
+      'Choose sell asset',
+    ) as HTMLSelectElement;
+    expect(sell.options).toHaveLength(4);
+    expect(sell.textContent).toContain('TOKEN');
+    expect(sell.textContent).toContain('WETH');
+    fireEvent.change(sell, { target: { value: contract } });
+    expect(
+      (screen.getByLabelText('Sell token') as HTMLInputElement).value,
+    ).toBe(contract);
+    expect(mocks.asset).toHaveBeenCalledWith(wallet, contract);
+  });
+  it('reveals unverified tokens with explicit labels and keeps them distinct by contract', () => {
+    mocks.tokens.mockReturnValue({
+      data: {
+        tokens: [
+          { ...to, verificationStatus: 'verified' },
+          {
+            ...to,
+            address: '0x3333333333333333333333333333333333333333',
+            verificationStatus: 'unknown',
+          },
+        ],
+      },
+      refetch: mocks.refetchTokens,
+    });
+    render(<ExternalWalletSwap />);
+    const sell = screen.getByLabelText(
+      'Choose sell asset',
+    ) as HTMLSelectElement;
+    expect(sell.options).toHaveLength(3);
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: 'Show unverified tokens (1)' }),
+    );
+    expect(sell.options).toHaveLength(4);
+    expect(sell.textContent).toContain('(unverified)');
+    expect(screen.getByText(/may include spam/)).toBeTruthy();
+    expect(sell.options[1].value).not.toBe(sell.options[2].value);
+  });
+  it('can refresh discovery and retain manual contract entry when discovery fails', () => {
+    mocks.tokens.mockReturnValue({
+      isError: true,
+      refetch: mocks.refetchTokens,
+    });
+    render(<ExternalWalletSwap />);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh token list' }));
+    expect(mocks.refetchTokens).toHaveBeenCalledOnce();
+    fireEvent.change(screen.getByLabelText('Sell token'), {
+      target: { value: contract },
+    });
+    expect(
+      (screen.getByLabelText('Choose sell asset') as HTMLSelectElement).value,
+    ).toBe('custom');
+    expect(mocks.asset).toHaveBeenCalledWith(wallet, contract);
+    expect(screen.getByText(/token list unavailable/)).toBeTruthy();
+  });
+  it('clears an existing quote when a different dropdown token is selected', async () => {
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    fireEvent.change(screen.getByLabelText('Choose sell asset'), {
+      target: { value: 'custom' },
+    });
+    expect(screen.queryByRole('button', { name: 'Review swap' })).toBeNull();
+  });
+  async function tokenQuote() {
+    const spender = '0x3333333333333333333333333333333333333333';
+    mocks.fresh.mockImplementation((_cache, _client, _wallet, token) =>
+      Promise.resolve(
+        token === zeroAddress ? from : { ...to, balance: 5000000n },
+      ),
+    );
+    mocks.quote.mockResolvedValue({
+      tool: 'test',
+      estimate: {
+        toAmount: '1000',
+        toAmountMin: '990',
+        approvalAddress: spender,
+      },
+      transactionRequest: { to: spender, data: '0xabcd', value: '0x0' },
+    });
+    fireEvent.change(screen.getByLabelText(/Sell token/), {
+      target: { value: contract },
+    });
+    fireEvent.change(screen.getByLabelText(/Buy token/), {
+      target: { value: 'ETH' },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '1.25' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    await screen.findByRole('button', { name: 'Approve TOKEN' });
+  }
+  it('approves only the exact amount before sending a token swap', async () => {
+    render(<ExternalWalletSwap />);
+    await tokenQuote();
+    mocks.readContract.mockResolvedValueOnce(0n).mockResolvedValue(1250000n);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve TOKEN' }));
+    await screen.findByRole('button', { name: 'Review swap' });
+    expect(mocks.request).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledTimes(2));
+    const approval = mocks.request.mock.calls[0][0].params[0];
+    expect(approval.chainId).toBe('0x2105');
+    expect(approval.to).toBe(contract);
+    expect(decodeFunctionData({ abi: erc20Abi, data: approval.data })).toEqual({
+      functionName: 'approve',
+      args: ['0x3333333333333333333333333333333333333333', 1250000n],
+    });
+  });
+  it('never sends the swap if the approval receipt reverted', async () => {
+    mocks.wait.mockResolvedValue({ status: 'reverted' });
+    render(<ExternalWalletSwap />);
+    await tokenQuote();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve TOKEN' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'approval reverted',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+  });
+  it('only reports confirmation after a successful receipt and refreshes balances', async () => {
+    const view = render(<ExternalWalletSwap />);
+    await getQuote();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await screen.findByRole('link');
+    mocks.receipt.mockReturnValue({
+      data: { transactionHash: hash, status: 'success' },
+      isError: false,
+    });
+    view.rerender(<ExternalWalletSwap />);
+    expect(screen.getByRole('status').textContent).toContain(
+      'Swap confirmed on Base',
+    );
+    expect(mocks.refresh).toHaveBeenCalledWith(mocks.queryClient, wallet);
+  });
+  it('blocks duplicate execution clicks', async () => {
+    let resolve!: (value: string) => void;
+    mocks.request.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    const button = screen.getByRole('button', { name: 'Review swap' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledOnce());
+    await act(async () => resolve(hash));
+  });
+  it('uses shared balances and gets a read-only quote', async () => {
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    expect(screen.getByText('Available on Base: 1 ETH')).toBeTruthy();
+    expect(mocks.asset).toHaveBeenCalledWith(wallet, contract);
+    expect(mocks.quote).toHaveBeenCalledWith(wallet, from, to, 1000000000000n);
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('checks balances again before signing and refreshes after submission', async () => {
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledOnce());
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: [expect.objectContaining({ chainId: '0x2105', from: wallet })],
+      }),
+    );
+    expect(mocks.refresh).toHaveBeenCalledWith(mocks.queryClient, wallet);
+    expect((await screen.findByRole('status')).textContent).toContain(
+      'Waiting for confirmation',
+    );
+  });
+  it('blocks spending when the live balance fell since the quote', async () => {
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    mocks.fresh.mockResolvedValue({ ...from, balance: 0n });
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Insufficient',
+    );
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('rejects excess fractional precision instead of rounding', async () => {
+    render(<ExternalWalletSwap />);
+    fireEvent.change(screen.getByLabelText(/Buy token/), {
+      target: { value: contract },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '0.0000000000000000001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Get quote' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'decimal places',
+    );
+    expect(mocks.quote).not.toHaveBeenCalled();
+  });
+  it('handles rejection without retrying the transaction', async () => {
+    mocks.request.mockRejectedValue(new Error('User rejected request'));
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'rejected',
+    );
+    expect(mocks.request).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+  it('requires new review if the refreshed minimum worsens', async () => {
+    render(<ExternalWalletSwap />);
+    await getQuote();
+    mocks.quote.mockResolvedValue({ estimate: { toAmountMin: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Quote changed',
+    );
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+  it('does not sign after the view unmounts during preflight', async () => {
+    let resolve!: () => void;
+    mocks.guard.mockImplementationOnce(
+      () =>
+        new Promise<void>((done) => {
+          resolve = done;
+        }),
+    );
+    const view = render(<ExternalWalletSwap />);
+    await getQuote();
+    fireEvent.click(screen.getByRole('button', { name: 'Review swap' }));
+    view.unmount();
+    await act(async () => resolve());
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+});

--- a/apps/farcaster-web/src/components/wallet/PreferredWalletDialog.tsx
+++ b/apps/farcaster-web/src/components/wallet/PreferredWalletDialog.tsx
@@ -72,7 +72,10 @@ export function PreferredWalletSelector({ modal }: { modal?: boolean }) {
   const { closeConnectModal, connectors, setPreferredWallet, preferredWallet } =
     useWallet();
   const [localPreferredWallet, setLocalPreferredWallet] = useState<string>();
-  const { connector: existingConnector } = useAccount();
+  const {
+    connector: existingConnector,
+    isConnected: isExternalWalletConnected,
+  } = useAccount();
   const [showAllWallets, setShowAllWallets] = useState(!modal);
   const geoRestricted = useWalletGeoRestricted();
   const { trackEvent } = useAnalytics();
@@ -103,12 +106,21 @@ export function PreferredWalletSelector({ modal }: { modal?: boolean }) {
   const handleConnect = useCallback(
     async (connector: Connector) => {
       // Default to base chain
-      if (!existingConnector || connector.id !== existingConnector.id) {
+      if (
+        !isExternalWalletConnected ||
+        !existingConnector ||
+        connector.id !== existingConnector.id
+      ) {
         await connectAsync({ connector: connector, chainId: base.id });
       }
       handleSelectPreferredWallet(connector.id);
     },
-    [connectAsync, existingConnector, handleSelectPreferredWallet],
+    [
+      connectAsync,
+      existingConnector,
+      handleSelectPreferredWallet,
+      isExternalWalletConnected,
+    ],
   );
 
   const handleDone = useCallback(() => {
@@ -196,7 +208,9 @@ export function PreferredWalletSelector({ modal }: { modal?: boolean }) {
                 onClick={() => handleConnect(connector)}
                 isSelected={localPreferredWallet === connector.id}
                 isConnected={
-                  existingConnector && connector.id === existingConnector.id
+                  isExternalWalletConnected &&
+                  existingConnector &&
+                  connector.id === existingConnector.id
                 }
                 isInstalled={connector.id !== 'walletConnect'}
               />
@@ -206,7 +220,7 @@ export function PreferredWalletSelector({ modal }: { modal?: boolean }) {
             </Fragment>
           );
         })}
-        {!showAllWallets && (
+        {!showAllWallets && localPreferredWallet !== 'walletConnect' && (
           <WalletOption
             name="External Wallet"
             icon={
@@ -236,6 +250,14 @@ export function PreferredWalletSelector({ modal }: { modal?: boolean }) {
               </svg>
             }
             onClick={() => {
+              const walletConnectConnector = connectors.find(
+                (connector) => connector.id === 'walletConnect',
+              );
+              if (walletConnectConnector) {
+                void handleConnect(walletConnectConnector);
+                return;
+              }
+
               setShowAllWallets(true);
             }}
           />

--- a/apps/farcaster-web/src/constants/api.ts
+++ b/apps/farcaster-web/src/constants/api.ts
@@ -18,16 +18,28 @@ function isLocalApiEnabled(): boolean {
 
 const useLocalApi = isLocalApiEnabled();
 
-const baseApiHost = useLocalApi ? 'localhost:8080' : 'farcaster.xyz/~api';
+const upstreamApiUrl = 'https://farcaster.xyz/~api';
 
-const baseUseHttps = !useLocalApi;
+// Farcaster allows its private web API from the official site and localhost,
+// but not arbitrary production origins. Hosted builds use the same-origin
+// Cloudflare Pages Function relay at /~api.
+const productionApiUrl =
+  typeof window === 'undefined'
+    ? upstreamApiUrl
+    : `${window.location.origin}/~api`;
 
-const baseApiUrl = baseUseHttps
-  ? `https://${baseApiHost}`
-  : `http://${baseApiHost}`;
+const baseApiUrl = useLocalApi
+  ? 'http://localhost:8080'
+  : isProd
+    ? productionApiUrl
+    : upstreamApiUrl;
+
+const parsedBaseApiUrl = new URL(baseApiUrl);
+const baseApiHost = `${parsedBaseApiUrl.host}${parsedBaseApiUrl.pathname}`;
+const baseUseHttps = parsedBaseApiUrl.protocol === 'https:';
 
 const wsUrl = useLocalApi
-  ? `ws://${baseApiHost}/stream`
+  ? 'ws://localhost:8080/stream'
   : 'wss://ws.farcaster.xyz/stream';
 
 export { baseApiHost, baseApiUrl, baseUseHttps, STORAGE_KEY, wsUrl };

--- a/apps/farcaster-web/src/contexts/WalletProvider.tsx
+++ b/apps/farcaster-web/src/contexts/WalletProvider.tsx
@@ -98,7 +98,11 @@ interface PendingConnectRequest {
 const WalletProvider = ({ children }: WalletProviderProps) => {
   // External hooks
   const connectors = useConnectors();
-  const { connector, address } = useAccount();
+  const {
+    connector,
+    address,
+    isConnected: isExternalWalletConnected,
+  } = useAccount();
   const { ethProvider, isConnected } = useEmbeddedWalletBridge();
 
   // State management
@@ -118,7 +122,7 @@ const WalletProvider = ({ children }: WalletProviderProps) => {
     { domain: string; iconUrl?: string } | undefined
   >(undefined);
   const pendingConnectRequestsRef = useRef<PendingConnectRequest[]>([]);
-  const isRunningRefresh = useRef(false);
+  const refreshQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   // Helper to update preferred wallet and trigger re-load if needed
   const setPreferredWalletInner = useCallback(
@@ -160,6 +164,27 @@ const WalletProvider = ({ children }: WalletProviderProps) => {
     setPreferredWalletInner(undefined);
     localStorage.removeItem(PREFERRED_WALLET_KEY);
   }, [setPreferredWalletInner]);
+
+  // Keep the active external connector and the wallet used by miniapps in
+  // sync. Wagmi can expose the connected address before connectAsync settles,
+  // so adopting the connector here avoids a temporary second selection step.
+  useEffect(() => {
+    if (
+      !isExternalWalletConnected ||
+      !connector ||
+      preferredWallet === 'warpcast' ||
+      preferredWallet === connector.id
+    ) {
+      return;
+    }
+
+    handleSetPreferredWallet(connector.id);
+  }, [
+    connector,
+    handleSetPreferredWallet,
+    isExternalWalletConnected,
+    preferredWallet,
+  ]);
 
   // Disconnected provider that queues requests while loading
   const disconnectedProvider = useMemo(
@@ -267,7 +292,11 @@ const WalletProvider = ({ children }: WalletProviderProps) => {
         const accounts = await ethProvider.request({ method: 'eth_accounts' });
         setWarpcastWalletAddress(accounts[0]);
         nextProvider = ethProvider as Provider.Provider;
-      } else if (connector) {
+      } else if (
+        preferredWallet !== 'warpcast' &&
+        connector &&
+        isExternalWalletConnected
+      ) {
         // Get external wallet provider (MetaMask, etc.)
         nextProvider = (await connector.getProvider()) as Provider.Provider;
       }
@@ -295,18 +324,21 @@ const WalletProvider = ({ children }: WalletProviderProps) => {
     if (!nextProvider && pendingConnectRequestsRef.current.length > 0) {
       openConnectModal();
     }
-  }, [preferredWallet, connector, ethProvider, openConnectModal]);
+  }, [
+    preferredWallet,
+    connector,
+    ethProvider,
+    openConnectModal,
+    isExternalWalletConnected,
+  ]);
 
-  // Refresh provider when dependencies change (prevents concurrent refreshes)
+  // Queue refreshes so connector updates are not dropped during restoration.
   useEffect(() => {
-    if (isRunningRefresh.current) {
-      return;
-    }
-
-    isRunningRefresh.current = true;
-    refreshConnectedProvider().finally(() => {
-      isRunningRefresh.current = false;
-    });
+    refreshQueueRef.current = refreshQueueRef.current
+      .then(refreshConnectedProvider)
+      .catch((error) => {
+        logError('[WalletProvider] Failed to refresh provider:', error);
+      });
   }, [refreshConnectedProvider, isConnected]);
 
   // Build context value

--- a/apps/farcaster-web/src/hooks/__tests__/useLifiWallet.test.tsx
+++ b/apps/farcaster-web/src/hooks/__tests__/useLifiWallet.test.tsx
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Address, PublicClient, zeroAddress } from 'viem';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchFreshLifiAsset,
+  refreshLifiWallet,
+  useLifiAsset,
+  useLifiWalletTokens,
+} from '~/hooks/useLifiWallet';
+import { LifiAsset, lifiBalanceKey } from '~/utils/lifiWallet';
+
+const mocks = vi.hoisted(() => ({
+  client: {},
+  metadata: vi.fn(),
+  discover: vi.fn(),
+  read: vi.fn(),
+}));
+vi.mock('wagmi', () => ({ usePublicClient: () => mocks.client }));
+vi.mock('~/utils/lifiWallet', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/utils/lifiWallet')>()),
+  fetchLifiToken: mocks.metadata,
+  fetchLifiWalletTokens: mocks.discover,
+  readLifiAsset: mocks.read,
+}));
+const wallet = '0x1111111111111111111111111111111111111111';
+const other = '0x2222222222222222222222222222222222222222';
+const token = {
+  chainId: 8453,
+  address: '0x3333333333333333333333333333333333333333' as const,
+  symbol: 'TOKEN',
+  name: 'Token',
+  decimals: 6,
+};
+let queryClient: QueryClient;
+function View({
+  name,
+  address = wallet,
+  contract = token.address,
+}: {
+  name: string;
+  address?: Address;
+  contract?: Address;
+}) {
+  const { data, isError } = useLifiAsset(address, contract);
+  return (
+    <p data-testid={name}>
+      {isError ? 'unavailable' : data ? data.balance.toString() : 'loading'}
+    </p>
+  );
+}
+function mount(children: React.ReactNode) {
+  return render(
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+  );
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, retryDelay: 0, gcTime: 0 } },
+  });
+  mocks.metadata.mockResolvedValue(token);
+  mocks.discover.mockResolvedValue({ tokens: [token], skipped: 0 });
+  mocks.read.mockReset().mockResolvedValue({ ...token, balance: 123n });
+});
+afterEach(() => {
+  cleanup();
+  queryClient.clear();
+});
+describe('shared LI.FI wallet cache', () => {
+  it('shows failed balance refreshes as unavailable, not a fabricated zero', async () => {
+    mount(
+      <>
+        <View name="portfolio" />
+        <View name="swap" />
+      </>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('swap').textContent).toBe('123'),
+    );
+    mocks.read.mockRejectedValue(new Error('RPC unavailable'));
+    await act(async () => {
+      await refreshLifiWallet(queryClient, wallet);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('swap').textContent).toBe('unavailable'),
+    );
+    expect(screen.getByTestId('portfolio').textContent).toBe('unavailable');
+    expect(
+      queryClient.getQueryData(lifiBalanceKey(wallet, token.address)),
+    ).toMatchObject({ balance: '123' });
+  });
+  it('does not let a cancelled background read overwrite the fresh preflight balance', async () => {
+    mount(
+      <>
+        <View name="portfolio" />
+        <View name="swap" />
+      </>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('swap').textContent).toBe('123'),
+    );
+    let resolveOld!: (value: LifiAsset) => void;
+    mocks.read.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+    );
+    let background!: Promise<void>;
+    act(() => {
+      background = refreshLifiWallet(queryClient, wallet);
+    });
+    await waitFor(() => expect(mocks.read).toHaveBeenCalledTimes(2));
+    mocks.read.mockResolvedValue({ ...token, balance: 0n });
+    await act(async () => {
+      const fresh = await fetchFreshLifiAsset(
+        queryClient,
+        mocks.client as PublicClient,
+        wallet,
+        token.address,
+      );
+      expect(fresh.balance).toBe(0n);
+      await background;
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('swap').textContent).toBe('0'),
+    );
+    await act(async () => {
+      resolveOld({ ...token, balance: 999n });
+    });
+    expect(screen.getByTestId('portfolio').textContent).toBe('0');
+    expect(screen.getByTestId('swap').textContent).toBe('0');
+    expect(
+      queryClient.getQueryData(lifiBalanceKey(wallet, token.address)),
+    ).toMatchObject({ balance: '0' });
+  });
+  it('ignores a late balance for the previously selected token', async () => {
+    let resolveOld!: (value: LifiAsset) => void;
+    mocks.read.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+    );
+    const view = mount(<View name="send" />);
+    await waitFor(() => expect(mocks.read).toHaveBeenCalledOnce());
+    mocks.metadata.mockResolvedValue({ ...token, address: other });
+    mocks.read.mockResolvedValue({ ...token, address: other, balance: 456n });
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <View name="send" contract={other} />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('send').textContent).toBe('456'),
+    );
+    await act(async () => {
+      resolveOld({ ...token, balance: 999n });
+    });
+    expect(screen.getByTestId('send').textContent).toBe('456');
+  });
+  it('deduplicates balances across portfolio, send and swap consumers', async () => {
+    mount(
+      <>
+        <View name="portfolio" />
+        <View name="send" />
+        <View name="swap" />
+      </>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('swap').textContent).toBe('123'),
+    );
+    expect(screen.getByTestId('portfolio').textContent).toBe('123');
+    expect(screen.getByTestId('send').textContent).toBe('123');
+    expect(mocks.read).toHaveBeenCalledOnce();
+    const cached = queryClient.getQueryData(
+      lifiBalanceKey(wallet, token.address),
+    );
+    expect(() => JSON.stringify(cached)).not.toThrow();
+    expect(cached).toMatchObject({ balance: '123' });
+  });
+  it('publishes preflight balances back to every consumer', async () => {
+    mount(
+      <>
+        <View name="portfolio" />
+        <View name="send" />
+        <View name="swap" />
+      </>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('send').textContent).toBe('123'),
+    );
+    mocks.read.mockResolvedValue({ ...token, balance: 0n });
+    await act(async () => {
+      await fetchFreshLifiAsset(
+        queryClient,
+        mocks.client as PublicClient,
+        wallet,
+        token.address,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('portfolio').textContent).toBe('0'),
+    );
+    expect(screen.getByTestId('send').textContent).toBe('0');
+    expect(screen.getByTestId('swap').textContent).toBe('0');
+  });
+  it('isolates late responses from a previously selected account', async () => {
+    let resolve!: (value: LifiAsset) => void;
+    mocks.read.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const view = mount(<View name="send" />);
+    await waitFor(() => expect(mocks.read).toHaveBeenCalledOnce());
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <View name="send" address={other} />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('send').textContent).toBe('123'),
+    );
+    await act(async () => resolve({ ...token, balance: 999n }));
+    expect(screen.getByTestId('send').textContent).toBe('123');
+  });
+  it('refreshes all active wallet balances after confirmation', async () => {
+    mount(<View name="portfolio" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('portfolio').textContent).toBe('123'),
+    );
+    mocks.read.mockResolvedValue({ ...token, balance: 500n });
+    await act(async () => {
+      await refreshLifiWallet(queryClient, wallet);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('portfolio').textContent).toBe('500'),
+    );
+  });
+  it('does not seed spendable amounts from the discovery API', async () => {
+    function Discovery() {
+      const { data } = useLifiWalletTokens(wallet);
+      return <p>{data ? 'discovered' : 'loading'}</p>;
+    }
+    mount(<Discovery />);
+    await screen.findByText('discovered');
+    expect(
+      queryClient.getQueryData(lifiBalanceKey(wallet, token.address)),
+    ).toBeUndefined();
+    expect(mocks.discover).toHaveBeenCalledWith(wallet, expect.anything());
+  });
+  it('keeps ETH and ERC-20 balances separate', async () => {
+    mocks.read.mockImplementation((_client, _wallet, metadata) =>
+      Promise.resolve({
+        ...metadata,
+        balance: metadata.address === zeroAddress ? 10n : 20n,
+      }),
+    );
+    mount(
+      <>
+        <View name="native" contract={zeroAddress} />
+        <View name="token" />
+      </>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('token').textContent).toBe('20'),
+    );
+    expect(screen.getByTestId('native').textContent).toBe('10');
+  });
+});

--- a/apps/farcaster-web/src/hooks/useLifiWallet.ts
+++ b/apps/farcaster-web/src/hooks/useLifiWallet.ts
@@ -1,0 +1,163 @@
+import {
+  QueryClient,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { Address, PublicClient, zeroAddress } from 'viem';
+import { base } from 'viem/chains';
+import { usePublicClient } from 'wagmi';
+
+import { createBaseTransferReader } from '~/utils/baseWalletTransfer';
+import {
+  BASE_NATIVE_TOKEN,
+  fetchLifiToken,
+  fetchLifiWalletTokens,
+  LifiAsset,
+  lifiBalanceKey,
+  lifiTokenKey,
+  lifiWalletKey,
+  normalizeLifiAddress,
+  readLifiAsset,
+} from '~/utils/lifiWallet';
+
+// The host persists React Query to localStorage using JSON. Cache exact unit
+// strings, and expose bigint to consumers without breaking that persistence.
+type CachedLifiAsset = Omit<LifiAsset, 'balance'> & { balance: string };
+const selectAsset = (asset: CachedLifiAsset): LifiAsset => ({
+  ...asset,
+  balance: BigInt(asset.balance),
+});
+
+function assetOptions(
+  queryClient: QueryClient,
+  client: PublicClient | undefined,
+  address: Address,
+  token: Address,
+) {
+  const canonicalToken = normalizeLifiAddress(token);
+  return {
+    queryKey: lifiBalanceKey(address, canonicalToken),
+    queryFn: async ({ signal }: { signal: AbortSignal }) => {
+      if (!client) {
+        throw new Error('Base connection is not ready.');
+      }
+      const metadata =
+        canonicalToken === zeroAddress
+          ? BASE_NATIVE_TOKEN
+          : await queryClient.fetchQuery({
+              queryKey: lifiTokenKey(canonicalToken),
+              queryFn: ({ signal: tokenSignal }) =>
+                fetchLifiToken(canonicalToken, tokenSignal),
+              staleTime: 60_000,
+            });
+      if (signal.aborted) {
+        throw new Error('Balance request cancelled.');
+      }
+      const asset = await readLifiAsset(client, address, metadata);
+      if (signal.aborted) {
+        throw new Error('Balance request cancelled.');
+      }
+      return { ...asset, balance: asset.balance.toString() };
+    },
+    staleTime: 15_000,
+    placeholderData: undefined,
+    select: selectAsset,
+    retry: 1,
+    refetchInterval: 30_000,
+  };
+}
+
+export function useLifiWalletTokens(address?: Address) {
+  const queryClient = useQueryClient();
+  return useQuery({
+    queryKey: [...lifiWalletKey(address ?? zeroAddress), 'tokens'],
+    enabled: Boolean(address),
+    queryFn: async ({ signal }) => {
+      if (!address) {
+        throw new Error('Connect a wallet first.');
+      }
+      const result = await fetchLifiWalletTokens(address, signal);
+      if (signal.aborted) {
+        throw new Error('Token request cancelled.');
+      }
+      for (const token of result.tokens) {
+        queryClient.setQueryData(lifiTokenKey(token.address), token);
+      }
+      return result;
+    },
+    staleTime: 30_000,
+    placeholderData: undefined,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+}
+
+export function useLifiAsset(address?: Address, token?: Address) {
+  const client = usePublicClient({ chainId: base.id });
+  const queryClient = useQueryClient();
+  return useQuery({
+    ...assetOptions(
+      queryClient,
+      client,
+      address ?? zeroAddress,
+      token ?? zeroAddress,
+    ),
+    enabled: Boolean(address && token && client),
+  });
+}
+
+export async function fetchFreshLifiAsset(
+  queryClient: QueryClient,
+  client: PublicClient,
+  address: Address,
+  token: Address,
+) {
+  const options = assetOptions(queryClient, client, address, token);
+  // Do not reuse a background read that started before this preflight check.
+  await queryClient.cancelQueries({ queryKey: options.queryKey, exact: true });
+  return selectAsset(
+    await queryClient.fetchQuery({ ...options, staleTime: 0 }),
+  );
+}
+
+export function useLifiAssets(address: Address, tokens: Address[]) {
+  const client = usePublicClient({ chainId: base.id });
+  const queryClient = useQueryClient();
+  return useQueries({
+    queries: tokens.map((token) => ({
+      ...assetOptions(queryClient, client, address, token),
+      enabled: Boolean(client),
+    })),
+  });
+}
+
+export function useLifiTransferReader() {
+  const client = usePublicClient({ chainId: base.id });
+  const queryClient = useQueryClient();
+  return useMemo(
+    () =>
+      client
+        ? {
+            ...createBaseTransferReader(client),
+            nativeBalance: async (wallet: Address) =>
+              (
+                await fetchFreshLifiAsset(
+                  queryClient,
+                  client,
+                  wallet,
+                  zeroAddress,
+                )
+              ).balance,
+            tokenDetails: (token: Address, wallet: Address) =>
+              fetchFreshLifiAsset(queryClient, client, wallet, token),
+          }
+        : undefined,
+    [client, queryClient],
+  );
+}
+
+export function refreshLifiWallet(queryClient: QueryClient, address: Address) {
+  return queryClient.invalidateQueries({ queryKey: lifiWalletKey(address) });
+}

--- a/apps/farcaster-web/src/utils/__tests__/baseWalletPortfolio.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/baseWalletPortfolio.test.ts
@@ -1,0 +1,141 @@
+import type { ApiEthFungibleTokenPosition } from 'farcaster-client-data';
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatPortfolioBalance,
+  formatPortfolioUsd,
+  selectBasePortfolioPositions,
+} from '~/utils/baseWalletPortfolio';
+
+const position = (overrides: Partial<ApiEthFungibleTokenPosition> = {}) =>
+  ({
+    id: 'test',
+    chain: 'base',
+    quantity: { int: '1234567', float: 1.234567 },
+    decimals: 6,
+    ...overrides,
+  }) as ApiEthFungibleTokenPosition;
+
+describe('Base portfolio', () => {
+  it('excludes native ETH even when hidden tokens are requested', () => {
+    const native = position({
+      address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      hidden: true,
+    });
+    expect(selectBasePortfolioPositions([native], false)).toEqual([]);
+    expect(selectBasePortfolioPositions([native], true)).toEqual([]);
+  });
+
+  it('keeps WETH and ERC-20 contracts named ETH', () => {
+    const weth = position({
+      id: 'weth',
+      symbol: 'WETH',
+      address: '0x4200000000000000000000000000000000000006',
+    });
+    const namedEth = position({
+      id: 'named-eth',
+      symbol: 'ETH',
+      address: '0x1111111111111111111111111111111111111111',
+    });
+    expect(selectBasePortfolioPositions([weth, namedEth], false)).toEqual([
+      weth,
+      namedEth,
+    ]);
+  });
+
+  it('filters other chains and both kinds of hidden flags without mutating input', () => {
+    const entries = [
+      position({ id: 'small', value: 1 }),
+      position({ id: 'other', chain: 'ethereum', value: 1000 }),
+      position({ id: 'hidden', hidden: true }),
+      position({ id: 'user-hidden', userHidden: true }),
+      position({ id: 'large', value: 10 }),
+    ];
+    expect(
+      selectBasePortfolioPositions(entries, false).map((p) => p.id),
+    ).toEqual(['large', 'small']);
+    expect(entries.map((p) => p.id)).toEqual([
+      'small',
+      'other',
+      'hidden',
+      'user-hidden',
+      'large',
+    ]);
+    expect(selectBasePortfolioPositions(entries, true)).toHaveLength(4);
+  });
+
+  it('places missing prices after priced positions, including actual zero', () => {
+    const entries = [
+      position({ id: 'unknown' }),
+      position({ id: 'zero', value: 0 }),
+    ];
+    expect(
+      selectBasePortfolioPositions(entries, false).map((p) => p.id),
+    ).toEqual(['zero', 'unknown']);
+  });
+
+  it.each([undefined, NaN, Infinity, -1])(
+    'does not turn invalid USD values into zero: %s',
+    (value) => {
+      expect(formatPortfolioUsd(value)).toBe('—');
+    },
+  );
+
+  it('distinguishes zero, dust, and priced holdings', () => {
+    expect(formatPortfolioUsd(0)).toBe('$0.00');
+    expect(formatPortfolioUsd(0.001)).toBe('<$0.01');
+    expect(formatPortfolioUsd(12.345)).toBe('$12.35');
+  });
+
+  it('uses integer units and decimals rather than the approximate float balance', () => {
+    expect(
+      formatPortfolioBalance(
+        position({ quantity: { int: '1234567', float: 99 } }),
+      ),
+    ).toEqual({ display: '1.234567', exact: '1.234567' });
+  });
+
+  it('preserves integer balances beyond the safe JS number range', () => {
+    expect(
+      formatPortfolioBalance(
+        position({
+          decimals: 0,
+          quantity: { int: '900719925474099312345', float: 0 },
+        }),
+      ),
+    ).toEqual({
+      display: '900,719,925,474,099,312,345',
+      exact: '900719925474099312345',
+    });
+  });
+
+  it('distinguishes very small balances from zero', () => {
+    expect(
+      formatPortfolioBalance(
+        position({ decimals: 18, quantity: { int: '1', float: 0 } }),
+      ).display,
+    ).toBe('<0.000001');
+    expect(
+      formatPortfolioBalance(position({ quantity: { int: '0', float: 0 } }))
+        .display,
+    ).toBe('0');
+  });
+
+  it('marks truncated fractions and retains the exact value', () => {
+    expect(
+      formatPortfolioBalance(
+        position({ decimals: 8, quantity: { int: '123456789', float: 0 } }),
+      ),
+    ).toEqual({ display: '1.234567…', exact: '1.23456789' });
+  });
+
+  it.each([
+    position({ decimals: undefined }),
+    position({ decimals: -1 }),
+    position({ decimals: 1.5 }),
+    position({ decimals: 256 }),
+    position({ quantity: { int: '1.2', float: 1.2 } }),
+  ])('handles malformed balance metadata without throwing', (entry) => {
+    expect(formatPortfolioBalance(entry).display).toBe('—');
+  });
+});

--- a/apps/farcaster-web/src/utils/__tests__/baseWalletTransfer.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/baseWalletTransfer.test.ts
@@ -1,0 +1,313 @@
+import { Provider } from 'ox';
+import {
+  decodeFunctionData,
+  erc20Abi,
+  parseEther,
+  PublicClient,
+  zeroAddress,
+} from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  BaseTransferInput,
+  BaseTransferReader,
+  createBaseTransferReader,
+  parseTransferAmount,
+  prepareBaseTransfer,
+  submitBaseTransfer,
+} from '~/utils/baseWalletTransfer';
+
+const address = '0x1111111111111111111111111111111111111111';
+const recipient = '0x2222222222222222222222222222222222222222';
+const tokenAddress = '0x3333333333333333333333333333333333333333';
+const hash = `0x${'a'.repeat(64)}`;
+const input: BaseTransferInput = {
+  address,
+  recipient,
+  amount: '1.25',
+  tokenAddress,
+};
+
+function setup() {
+  const reader = {
+    nativeBalance: vi.fn().mockResolvedValue(parseEther('10')),
+    tokenDetails: vi
+      .fn()
+      .mockResolvedValue({ symbol: 'TOKEN', decimals: 6, balance: 5_000_000n }),
+    simulateToken: vi.fn().mockResolvedValue(undefined),
+    estimateFee: vi.fn().mockResolvedValue(1_000_000_000_000n),
+  } satisfies BaseTransferReader;
+  let chain = '0x2105';
+  let accounts: string[] = [address];
+  const request = vi.fn(
+    async ({ method, params }: { method: string; params?: unknown }) => {
+      if (method === 'eth_chainId') {
+        return chain;
+      }
+      if (method === 'eth_accounts') {
+        return accounts;
+      }
+      if (method === 'wallet_switchEthereumChain') {
+        chain = '0x2105';
+        return null;
+      }
+      if (method === 'eth_sendTransaction') {
+        return hash;
+      }
+      throw new Error(`Unexpected method ${method}: ${params}`);
+    },
+  );
+  const provider = { request } as unknown as Pick<Provider.Provider, 'request'>;
+  const sent = () =>
+    request.mock.calls.filter(
+      ([call]) => call.method === 'eth_sendTransaction',
+    );
+  return {
+    reader,
+    request,
+    provider,
+    sent,
+    setChain: (next: string) => {
+      chain = next;
+    },
+    setAccounts: (next: string[]) => {
+      accounts = next;
+    },
+  };
+}
+
+describe('Base transfer amounts', () => {
+  it('parses token amounts exactly without floats', () => {
+    expect(parseTransferAmount('1.25', 6)).toBe(1_250_000n);
+    expect(parseTransferAmount('9007199254740993', 0)).toBe(9007199254740993n);
+  });
+  it.each(['0', '-1', '1e3', 'NaN', '', '1,000', '.'])(
+    'rejects invalid amount %s',
+    (amount) => {
+      expect(() => parseTransferAmount(amount, 6)).toThrow();
+    },
+  );
+  it('rejects excess precision instead of rounding', () => {
+    expect(() => parseTransferAmount('0.0000001', 6)).toThrow('decimal places');
+  });
+  it.each([-1, 256, 1.5])('rejects invalid decimals %s', (decimals) => {
+    expect(() => parseTransferAmount('1', decimals)).toThrow('decimals');
+  });
+});
+
+describe('prepareBaseTransfer', () => {
+  it('encodes transfer with the recipient and exact amount; no approval', async () => {
+    const { reader } = setup();
+    const prepared = await prepareBaseTransfer(reader, input);
+    expect(prepared.call.to).toBe(tokenAddress);
+    expect(prepared.call.value).toBe(0n);
+    expect(
+      decodeFunctionData({ abi: erc20Abi, data: prepared.call.data! }),
+    ).toEqual({
+      functionName: 'transfer',
+      args: [recipient, 1_250_000n],
+    });
+    expect(reader.simulateToken).toHaveBeenCalledWith(prepared.call);
+    expect(reader.estimateFee).toHaveBeenCalledWith(prepared.call);
+  });
+  it('prepares native ETH without a token contract call', async () => {
+    const { reader } = setup();
+    const prepared = await prepareBaseTransfer(reader, {
+      ...input,
+      tokenAddress: undefined,
+      amount: '0.1',
+    });
+    expect(prepared.call).toEqual({
+      account: address,
+      to: recipient,
+      value: parseEther('0.1'),
+    });
+    expect(reader.tokenDetails).not.toHaveBeenCalled();
+    expect(reader.simulateToken).not.toHaveBeenCalled();
+  });
+  it.each(['invalid', zeroAddress])(
+    'rejects recipient %s before RPC work',
+    async (recipient) => {
+      const { reader } = setup();
+      await expect(
+        prepareBaseTransfer(reader, { ...input, recipient }),
+      ).rejects.toThrow('recipient');
+      expect(reader.nativeBalance).not.toHaveBeenCalled();
+    },
+  );
+  it('rejects insufficient live token balance', async () => {
+    const { reader } = setup();
+    reader.tokenDetails.mockResolvedValue({
+      symbol: 'TOKEN',
+      decimals: 6,
+      balance: 1n,
+    });
+    await expect(prepareBaseTransfer(reader, input)).rejects.toThrow(
+      'Insufficient TOKEN balance. Available: 0.000001 TOKEN on Base.',
+    );
+  });
+  it('requires ETH for gas even when token balance is sufficient', async () => {
+    const { reader } = setup();
+    reader.nativeBalance.mockResolvedValue(1_000_000_000_000n);
+    await expect(prepareBaseTransfer(reader, input)).rejects.toThrow(
+      '20% fee buffer',
+    );
+  });
+  it('reserves fees in addition to the native amount', async () => {
+    const { reader } = setup();
+    reader.nativeBalance.mockResolvedValue(parseEther('1.25'));
+    await expect(
+      prepareBaseTransfer(reader, { ...input, tokenAddress: undefined }),
+    ).rejects.toThrow('estimated gas');
+  });
+  it('stops when token simulation fails', async () => {
+    const { reader } = setup();
+    reader.simulateToken.mockRejectedValue(new Error('Transfer restricted'));
+    await expect(prepareBaseTransfer(reader, input)).rejects.toThrow(
+      'Transfer restricted',
+    );
+    expect(reader.estimateFee).not.toHaveBeenCalled();
+  });
+});
+
+describe('submitBaseTransfer', () => {
+  it('switches to Base, checks fresh balances and submits one exact transfer', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.setChain('0x1');
+    await expect(submitBaseTransfer({ ...fixture, prepared })).resolves.toBe(
+      hash,
+    );
+    expect(fixture.reader.tokenDetails).toHaveBeenCalledTimes(2);
+    expect(fixture.sent()).toHaveLength(1);
+    expect(fixture.request).toHaveBeenLastCalledWith({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: address,
+          to: tokenAddress,
+          value: '0x0',
+          data: prepared.call.data,
+          chainId: '0x2105',
+        },
+      ],
+    });
+  });
+  it('blocks an expired review without opening the wallet', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    prepared.preparedAt -= 61_000;
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'expired',
+    );
+    expect(fixture.request).not.toHaveBeenCalled();
+  });
+  it('blocks an account change', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.setAccounts([recipient]);
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'account changed',
+    );
+    expect(fixture.sent()).toHaveLength(0);
+  });
+  it('blocks changed token decimals', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.reader.tokenDetails.mockResolvedValue({
+      symbol: 'TOKEN',
+      decimals: 7,
+      balance: 50_000_000n,
+    });
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'Token details changed',
+    );
+    expect(fixture.sent()).toHaveLength(0);
+  });
+  it('blocks a balance that fell since review', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.reader.tokenDetails.mockResolvedValue({
+      symbol: 'TOKEN',
+      decimals: 6,
+      balance: 0n,
+    });
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'Insufficient',
+    );
+    expect(fixture.sent()).toHaveLength(0);
+  });
+  it('blocks a network change during the final RPC checks without switching again', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.reader.estimateFee.mockImplementation(async () => {
+      fixture.setChain('0x1');
+      return 100n;
+    });
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'not on Base',
+    );
+    expect(fixture.sent()).toHaveLength(0);
+  });
+  it('blocks a stale view after asynchronous work', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    let current = true;
+    fixture.reader.estimateFee.mockImplementation(async () => {
+      current = false;
+      return 100n;
+    });
+    await expect(
+      submitBaseTransfer({ ...fixture, prepared, isCurrent: () => current }),
+    ).rejects.toThrow('form changed');
+    expect(fixture.sent()).toHaveLength(0);
+  });
+  it('propagates rejection without retrying the send', async () => {
+    const fixture = setup();
+    const prepared = await prepareBaseTransfer(fixture.reader, input);
+    fixture.request.mockImplementation(async ({ method }) => {
+      if (method === 'eth_chainId') {
+        return '0x2105';
+      }
+      if (method === 'eth_accounts') {
+        return [address];
+      }
+      throw new Error('User rejected');
+    });
+    await expect(submitBaseTransfer({ ...fixture, prepared })).rejects.toThrow(
+      'User rejected',
+    );
+    expect(fixture.sent()).toHaveLength(1);
+  });
+});
+
+describe('live RPC simulation adapter', () => {
+  it('rejects a client configured for another chain', () => {
+    expect(() =>
+      createBaseTransferReader({ chain: { id: 1 } } as PublicClient),
+    ).toThrow('Base RPC');
+  });
+  it.each(['0x', `0x${'0'.repeat(63)}1`])(
+    'accepts successful/no-return ERC-20 simulation %s',
+    async (data) => {
+      const call = vi.fn().mockResolvedValue({ data });
+      const reader = createBaseTransferReader({
+        chain: { id: 8453 },
+        call,
+      } as unknown as PublicClient);
+      await expect(
+        reader.simulateToken({ account: address, to: tokenAddress, value: 0n }),
+      ).resolves.toBeUndefined();
+    },
+  );
+  it('rejects an explicit false transfer result', async () => {
+    const call = vi.fn().mockResolvedValue({ data: `0x${'0'.repeat(64)}` });
+    const reader = createBaseTransferReader({
+      chain: { id: 8453 },
+      call,
+    } as unknown as PublicClient);
+    await expect(
+      reader.simulateToken({ account: address, to: tokenAddress, value: 0n }),
+    ).rejects.toThrow('returned false');
+  });
+});

--- a/apps/farcaster-web/src/utils/__tests__/lifiSwap.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/lifiSwap.test.ts
@@ -1,0 +1,80 @@
+import { zeroAddress } from 'viem';
+import { describe, expect, it } from 'vitest';
+
+import { LifiQuote, validateLifiQuote } from '~/utils/lifiSwap';
+import { BASE_NATIVE_TOKEN } from '~/utils/lifiWallet';
+const wallet = '0x1111111111111111111111111111111111111111';
+const from = { ...BASE_NATIVE_TOKEN, balance: 1000n };
+const to = {
+  ...from,
+  address: '0x2222222222222222222222222222222222222222' as const,
+  decimals: 6,
+};
+const makeQuote = (): LifiQuote => ({
+  tool: 'test',
+  action: {
+    fromChainId: 8453,
+    toChainId: 8453,
+    fromAddress: wallet,
+    toAddress: wallet,
+    fromAmount: '100',
+    fromToken: from,
+    toToken: to,
+  },
+  estimate: { toAmount: '1000', toAmountMin: '990' },
+  transactionRequest: {
+    chainId: 8453,
+    from: wallet,
+    to: to.address,
+    data: '0xabcd',
+    value: '0x64',
+  },
+});
+describe('LI.FI quote validation', () => {
+  it('accepts a matching same-chain swap', () =>
+    expect(() =>
+      validateLifiQuote(makeQuote(), wallet, from, to, 100n),
+    ).not.toThrow());
+  it.each([
+    (q: LifiQuote) => {
+      q.action.toChainId = 1;
+    },
+    (q: LifiQuote) => {
+      q.action.toAddress = to.address;
+    },
+    (q: LifiQuote) => {
+      q.action.fromAmount = '101';
+    },
+    (q: LifiQuote) => {
+      q.action.toToken = { ...to, decimals: 18 };
+    },
+    (q: LifiQuote) => {
+      q.action.fromToken = { ...from, address: to.address };
+    },
+    (q: LifiQuote) => {
+      q.estimate.toAmountMin = '0';
+    },
+    (q: LifiQuote) => {
+      q.estimate.toAmountMin = '1001';
+    },
+    (q: LifiQuote) => {
+      q.transactionRequest.chainId = 1;
+    },
+    (q: LifiQuote) => {
+      q.transactionRequest.from = to.address;
+    },
+    (q: LifiQuote) => {
+      q.transactionRequest.to = zeroAddress;
+    },
+    (q: LifiQuote) => {
+      q.estimate.approvalAddress = zeroAddress;
+    },
+    (q: LifiQuote) => {
+      q.transactionRequest.value = '0x01';
+    },
+  ])('rejects mismatched or malformed quotes %#', (change) => {
+    const q = makeQuote();
+    change(q);
+    expect(() => validateLifiQuote(q, wallet, from, to, 100n)).toThrow();
+  });
+});

--- a/apps/farcaster-web/src/utils/__tests__/lifiWallet.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/lifiWallet.test.ts
@@ -1,0 +1,197 @@
+import { PublicClient, zeroAddress } from 'viem';
+import { base } from 'viem/chains';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BASE_NATIVE_TOKEN,
+  fetchLifiToken,
+  fetchLifiWalletTokens,
+  formatLifiBalance,
+  lifiAssetUsd,
+  lifiBalanceKey,
+  normalizeLifiAddress,
+  parseLifiToken,
+  readLifiAsset,
+  requestLifi,
+} from '~/utils/lifiWallet';
+
+const wallet = '0x1111111111111111111111111111111111111111';
+const token = {
+  chainId: 8453,
+  address: '0x2222222222222222222222222222222222222222' as const,
+  symbol: 'TOKEN',
+  name: 'Token',
+  decimals: 6,
+  priceUSD: '2',
+  amount: '999999999999',
+};
+const respond = (body: unknown, status = 200) => {
+  const mock = vi
+    .fn()
+    .mockResolvedValue({ ok: status === 200, status, json: async () => body });
+  vi.stubGlobal('fetch', mock);
+  return mock;
+};
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+describe('LI.FI wallet data', () => {
+  it('discovers only Base tokens and never copies indexed amounts into live balances', async () => {
+    const fetch = respond({
+      walletAddress: wallet,
+      balances: { 8453: [token], 1: [{ ...token, chainId: 1 }] },
+      limit: 1000,
+    });
+    const result = await fetchLifiWalletTokens(wallet);
+    expect(result.tokens).toEqual([
+      {
+        chainId: 8453,
+        address: token.address,
+        symbol: 'TOKEN',
+        name: 'Token',
+        decimals: 6,
+        priceUSD: 2,
+      },
+    ]);
+    expect(result.tokens[0]).not.toHaveProperty('balance');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/wallets/${wallet}/balances?extended=true`),
+      expect.objectContaining({
+        credentials: 'omit',
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      }),
+    );
+  });
+  it('treats a valid response without Base entries as empty', async () => {
+    respond({ walletAddress: wallet, balances: {} });
+    expect((await fetchLifiWalletTokens(wallet)).tokens).toEqual([]);
+  });
+  it.each([
+    {},
+    { walletAddress: wallet },
+    { walletAddress: token.address, balances: {} },
+    { walletAddress: wallet, balances: { 8453: {} } },
+  ])(
+    'does not present malformed or wrong-account responses as empty: %j',
+    async (body) => {
+      respond(body);
+      await expect(fetchLifiWalletTokens(wallet)).rejects.toThrow();
+    },
+  );
+  it('deduplicates contracts and reports partial responses', async () => {
+    respond({
+      walletAddress: wallet,
+      balances: {
+        8453: [
+          token,
+          token,
+          { ...token, decimals: -1 },
+          { ...token, chainId: 1 },
+        ],
+      },
+      limit: 4,
+    });
+    const result = await fetchLifiWalletTokens(wallet);
+    expect(result.tokens).toHaveLength(1);
+    expect(result.skipped).toBe(2);
+    expect(result.possiblyLimited).toBe(true);
+  });
+  it.each(['', 'garbage', '-2', 'Infinity'])(
+    'treats price %s as unavailable, not zero',
+    (priceUSD) => {
+      expect(parseLifiToken({ ...token, priceUSD }).priceUSD).toBeUndefined();
+    },
+  );
+  it('preserves genuine zero prices', () =>
+    expect(parseLifiToken({ ...token, priceUSD: '0' }).priceUSD).toBe(0));
+  it('normalizes native aliases without misidentifying WETH', () => {
+    expect(normalizeLifiAddress('ETH')).toBe(zeroAddress);
+    expect(
+      normalizeLifiAddress('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'),
+    ).toBe(zeroAddress);
+    expect(
+      normalizeLifiAddress('0x4200000000000000000000000000000000000006'),
+    ).not.toBe(zeroAddress);
+  });
+  it('rejects wrong contracts returned by token lookup', async () => {
+    respond({ ...token, address: wallet });
+    await expect(fetchLifiToken(token.address)).rejects.toThrow(
+      'different token',
+    );
+  });
+  it('surfaces rate limits as errors', async () => {
+    respond({}, 429);
+    await expect(fetchLifiWalletTokens(wallet)).rejects.toThrow(
+      'rate limiting',
+    );
+  });
+  it('forwards cancellation to the HTTP request', async () => {
+    const fetch = respond({});
+    const controller = new AbortController();
+    controller.abort();
+    await requestLifi('/token', controller.signal);
+    expect(fetch.mock.calls[0][1].signal.aborted).toBe(true);
+  });
+  it('uses exact integer units and live balances for valuation', async () => {
+    const readContract = vi
+      .fn()
+      .mockImplementation(({ functionName }) =>
+        Promise.resolve(
+          functionName === 'decimals' ? 6 : 9007199254740993000001n,
+        ),
+      );
+    const client = { chain: base, readContract } as unknown as PublicClient;
+    const asset = await readLifiAsset(client, wallet, parseLifiToken(token));
+    expect(formatLifiBalance(asset)).toBe('9007199254740993.000001');
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: token.address,
+        functionName: 'balanceOf',
+        args: [wallet],
+      }),
+    );
+    expect(lifiAssetUsd({ ...asset, balance: 1000000n })).toBe(2);
+    expect(lifiAssetUsd({ ...asset, priceUSD: undefined })).toBeUndefined();
+  });
+  it('keeps live zero as zero even when LI.FI indexed a positive holding', async () => {
+    const client = {
+      chain: base,
+      readContract: vi
+        .fn()
+        .mockImplementation(({ functionName }) =>
+          Promise.resolve(functionName === 'decimals' ? 6 : 0n),
+        ),
+    } as unknown as PublicClient;
+    expect(
+      (await readLifiAsset(client, wallet, parseLifiToken(token))).balance,
+    ).toBe(0n);
+  });
+  it('rejects RPC errors and decimals mismatches instead of returning zero', async () => {
+    const readContract = vi.fn().mockRejectedValue(new Error('offline'));
+    const client = { chain: base, readContract } as unknown as PublicClient;
+    await expect(
+      readLifiAsset(client, wallet, parseLifiToken(token)),
+    ).rejects.toThrow('offline');
+    readContract.mockResolvedValue(18);
+    await expect(
+      readLifiAsset(client, wallet, parseLifiToken(token)),
+    ).rejects.toThrow('decimals');
+  });
+  it('scopes every balance to Base and wallet + contract', async () => {
+    expect(lifiBalanceKey(wallet, token.address)).not.toEqual(
+      lifiBalanceKey(token.address, token.address),
+    );
+    expect(lifiBalanceKey(wallet, token.address)).not.toEqual(
+      lifiBalanceKey(wallet, zeroAddress),
+    );
+    await expect(
+      readLifiAsset(
+        { chain: { id: 1 } } as PublicClient,
+        wallet,
+        BASE_NATIVE_TOKEN,
+      ),
+    ).rejects.toThrow('Base');
+  });
+});

--- a/apps/farcaster-web/src/utils/__tests__/readConfirmedAllowance.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/readConfirmedAllowance.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { readConfirmedAllowance } from '~/utils/readConfirmedAllowance';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+function options(read = vi.fn().mockResolvedValue(25n)) {
+  return { read, assertCurrent: vi.fn(), onRetry: vi.fn() };
+}
+
+describe('confirmed allowance RPC catch-up', () => {
+  it('returns immediately when the block is available', async () => {
+    const input = options();
+    expect(await readConfirmedAllowance(input)).toBe(25n);
+    expect(input.read).toHaveBeenCalledOnce();
+    expect(input.onRetry).not.toHaveBeenCalled();
+  });
+  it('returns a real zero without retrying or inventing allowance', async () => {
+    const input = options(vi.fn().mockResolvedValue(0n));
+    expect(await readConfirmedAllowance(input)).toBe(0n);
+    expect(input.read).toHaveBeenCalledOnce();
+  });
+  it('waits between missing-block responses and returns the eventual allowance', async () => {
+    const input = options(
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error('block not found: 0x305b0a6'))
+        .mockRejectedValueOnce({ cause: { details: 'header not found' } })
+        .mockResolvedValue(25n),
+    );
+    const result = readConfirmedAllowance(input);
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(input.read).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(input.read).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(await result).toBe(25n);
+    expect(input.onRetry).toHaveBeenCalledTimes(2);
+  });
+  it('stops after eight attempts with a clear message', async () => {
+    const input = options(
+      vi.fn().mockRejectedValue(new Error('unknown block')),
+    );
+    const result = expect(readConfirmedAllowance(input)).rejects.toThrow(
+      'Approval confirmed, but Base RPC could not read its block yet',
+    );
+    await vi.runAllTimersAsync();
+    await result;
+    expect(input.read).toHaveBeenCalledTimes(8);
+    expect(input.onRetry).toHaveBeenCalledTimes(7);
+  });
+  it.each(['execution reverted', 'HTTP 403', 'invalid address'])(
+    'does not retry an unrelated failure: %s',
+    async (message) => {
+      const input = options(vi.fn().mockRejectedValue(new Error(message)));
+      await expect(readConfirmedAllowance(input)).rejects.toThrow(message);
+      expect(input.read).toHaveBeenCalledOnce();
+      expect(input.onRetry).not.toHaveBeenCalled();
+    },
+  );
+  it('stops before another read when the wallet changes during the delay', async () => {
+    const input = options(
+      vi.fn().mockRejectedValue(new Error('block not found')),
+    );
+    const result = expect(readConfirmedAllowance(input)).rejects.toThrow(
+      'Wallet changed',
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    input.assertCurrent.mockImplementation(() => {
+      throw new Error('Wallet changed');
+    });
+    await vi.runAllTimersAsync();
+    await result;
+    expect(input.read).toHaveBeenCalledOnce();
+  });
+  it('rejects a late read after the wallet changes', async () => {
+    let resolve!: (value: bigint) => void;
+    const input = options(
+      vi.fn().mockImplementation(
+        () =>
+          new Promise((done) => {
+            resolve = done;
+          }),
+      ),
+    );
+    const result = expect(readConfirmedAllowance(input)).rejects.toThrow(
+      'Wallet changed',
+    );
+    input.assertCurrent.mockImplementation(() => {
+      throw new Error('Wallet changed');
+    });
+    resolve(25n);
+    await result;
+    expect(input.onRetry).not.toHaveBeenCalled();
+  });
+  it('handles cyclic error causes without looping', async () => {
+    const error: { message: string; cause?: unknown } = {
+      message: 'RPC failed',
+    };
+    error.cause = error;
+    const input = options(vi.fn().mockRejectedValue(error));
+    await expect(readConfirmedAllowance(input)).rejects.toBe(error);
+    expect(input.read).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/farcaster-web/src/utils/__tests__/sendBaseNativeToken.test.ts
+++ b/apps/farcaster-web/src/utils/__tests__/sendBaseNativeToken.test.ts
@@ -1,0 +1,118 @@
+import { Provider } from 'ox';
+import { describe, expect, it, vi } from 'vitest';
+
+import { sendBaseNativeToken } from '~/utils/sendBaseNativeToken';
+
+const address = '0x1111111111111111111111111111111111111111';
+const recipient = '0x2222222222222222222222222222222222222222';
+const hash = `0x${'a'.repeat(64)}`;
+
+function setup({
+  initialChain = '0x2105',
+  switchedChain = '0x2105',
+  accounts = [address],
+  switchRejected = false,
+  sendRejected = false,
+} = {}) {
+  let chain = initialChain;
+  const request = vi.fn(async ({ method }: { method: string }) => {
+    switch (method) {
+      case 'eth_chainId':
+        return chain;
+      case 'eth_accounts':
+        return accounts;
+      case 'wallet_switchEthereumChain':
+        if (switchRejected) {
+          throw new Error('Switch rejected');
+        }
+        chain = switchedChain;
+        return null;
+      case 'eth_sendTransaction':
+        if (sendRejected) {
+          throw new Error('Send rejected');
+        }
+        return hash;
+      default:
+        throw new Error(`Unexpected method: ${method}`);
+    }
+  });
+  const send = () =>
+    sendBaseNativeToken({
+      provider: { request } as unknown as Pick<Provider.Provider, 'request'>,
+      address,
+      recipient,
+      value: 1n,
+    });
+  const methods = () => request.mock.calls.map(([call]) => call.method);
+  return { request, send, methods };
+}
+
+describe('sendBaseNativeToken', () => {
+  it('sends on Base without prompting to switch', async () => {
+    const { request, send, methods } = setup();
+    await expect(send()).resolves.toBe(hash);
+    expect(methods()).toEqual([
+      'eth_chainId',
+      'eth_accounts',
+      'eth_chainId',
+      'eth_sendTransaction',
+    ]);
+    expect(request).toHaveBeenLastCalledWith({
+      method: 'eth_sendTransaction',
+      params: [
+        { from: address, to: recipient, value: '0x1', chainId: '0x2105' },
+      ],
+    });
+  });
+
+  it('switches from another network and verifies before sending', async () => {
+    const { request, send, methods } = setup({ initialChain: '0x1' });
+    await expect(send()).resolves.toBe(hash);
+    expect(request).toHaveBeenNthCalledWith(2, {
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0x2105' }],
+    });
+    expect(methods()).toEqual([
+      'eth_chainId',
+      'wallet_switchEthereumChain',
+      'eth_accounts',
+      'eth_chainId',
+      'eth_sendTransaction',
+    ]);
+  });
+
+  it('does not send when switching is rejected', async () => {
+    const { send, methods } = setup({
+      initialChain: '0x1',
+      switchRejected: true,
+    });
+    await expect(send()).rejects.toThrow('Switch rejected');
+    expect(methods()).not.toContain('eth_sendTransaction');
+  });
+
+  it('does not send if the wallet remains on another network', async () => {
+    const { send, methods } = setup({
+      initialChain: '0x1',
+      switchedChain: '0x1',
+    });
+    await expect(send()).rejects.toThrow('Wallet is not on Base');
+    expect(methods()).not.toContain('eth_sendTransaction');
+  });
+
+  it.each([{ accounts: [recipient] }, { accounts: [] }])(
+    'does not send with changed or missing accounts: $accounts',
+    async ({ accounts }) => {
+      const { send, methods } = setup({ accounts });
+      await expect(send()).rejects.toThrow('Wallet account changed');
+      expect(methods()).not.toContain('eth_sendTransaction');
+    },
+  );
+
+  it('propagates transaction rejection without retrying', async () => {
+    const { send, methods } = setup({ sendRejected: true });
+    await expect(send()).rejects.toThrow('Send rejected');
+    expect(
+      methods().filter((method) => method === 'eth_sendTransaction'),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/farcaster-web/src/utils/baseWalletPortfolio.ts
+++ b/apps/farcaster-web/src/utils/baseWalletPortfolio.ts
@@ -1,0 +1,80 @@
+import type { ApiEthFungibleTokenPosition } from 'farcaster-client-data';
+import { formatUnits } from 'viem';
+
+// Farcaster's native-asset marker for Base. Never identify native ETH by
+// symbol: WETH and contracts that call themselves ETH remain separate tokens.
+const BASE_NATIVE_ASSET_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+export const isBasePortfolioToken = (position: ApiEthFungibleTokenPosition) =>
+  position.chain === 'base' &&
+  position.address?.toLowerCase() !== BASE_NATIVE_ASSET_ADDRESS;
+
+export const isPortfolioPositionHidden = (
+  position: ApiEthFungibleTokenPosition,
+) => Boolean(position.hidden || position.userHidden);
+
+export function selectBasePortfolioPositions(
+  positions: ApiEthFungibleTokenPosition[],
+  showHidden: boolean,
+) {
+  return positions
+    .filter(
+      (position) =>
+        isBasePortfolioToken(position) &&
+        (showHidden || !isPortfolioPositionHidden(position)),
+    )
+    .sort(
+      (a, b) =>
+        (getPortfolioUsdValue(b.value) ?? -1) -
+        (getPortfolioUsdValue(a.value) ?? -1),
+    );
+}
+
+export function getPortfolioUsdValue(value: number | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+export function formatPortfolioUsd(value: number | undefined) {
+  const validValue = getPortfolioUsdValue(value);
+  if (validValue === undefined) {
+    return '—';
+  }
+  if (validValue > 0 && validValue < 0.01) {
+    return '<$0.01';
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(validValue);
+}
+
+// Format integer token units without converting the balance to a JS number.
+// API valuations are display estimates; sending will read live chain balances.
+export function formatPortfolioBalance(position: ApiEthFungibleTokenPosition) {
+  const units = position.quantity?.int;
+  const decimals = position.decimals;
+  if (
+    typeof units !== 'string' ||
+    !/^\d+$/.test(units) ||
+    decimals === undefined ||
+    !Number.isInteger(decimals) ||
+    decimals < 0 ||
+    decimals > 255
+  ) {
+    return { display: '—', exact: 'Balance unavailable' };
+  }
+
+  const exact = formatUnits(BigInt(units), decimals);
+  const [whole, fraction = ''] = exact.split('.');
+  const groupedWhole = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  if (whole === '0' && fraction.length > 6 && /^0{6}/.test(fraction)) {
+    return { display: '<0.000001', exact };
+  }
+  const visibleFraction = fraction.slice(0, 6).replace(/0+$/, '');
+  return {
+    display: `${groupedWhole}${visibleFraction ? `.${visibleFraction}` : ''}${fraction.length > 6 ? '…' : ''}`,
+    exact,
+  };
+}

--- a/apps/farcaster-web/src/utils/baseWalletTransfer.ts
+++ b/apps/farcaster-web/src/utils/baseWalletTransfer.ts
@@ -1,0 +1,239 @@
+import { Provider } from 'ox';
+import {
+  Address,
+  decodeFunctionResult,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  Hex,
+  isAddress,
+  parseUnits,
+  PublicClient,
+  toHex,
+  zeroAddress,
+} from 'viem';
+import { base } from 'viem/chains';
+import { estimateTotalFee } from 'viem/op-stack';
+
+import { ensureBaseWalletAccount } from '~/utils/sendBaseNativeToken';
+
+export type BaseTransferInput = {
+  address: Address;
+  recipient: string;
+  amount: string;
+  tokenAddress?: Address;
+};
+type TransferCall = {
+  account: Address;
+  to: Address;
+  value: bigint;
+  data?: Hex;
+};
+export type BaseTransferReader = {
+  nativeBalance: (address: Address) => Promise<bigint>;
+  tokenDetails: (
+    token: Address,
+    address: Address,
+  ) => Promise<{ symbol: string; decimals: number; balance: bigint }>;
+  simulateToken: (call: TransferCall) => Promise<void>;
+  estimateFee: (call: TransferCall) => Promise<bigint>;
+};
+export type PreparedBaseTransfer = {
+  input: BaseTransferInput;
+  call: TransferCall;
+  units: bigint;
+  decimals: number;
+  symbol: string;
+  balance: bigint;
+  estimatedFee: bigint;
+  preparedAt: number;
+};
+
+export function createBaseTransferReader(
+  client: PublicClient,
+): BaseTransferReader {
+  if (client.chain?.id !== base.id) {
+    throw new Error('Base RPC is required.');
+  }
+  return {
+    nativeBalance: (address) => client.getBalance({ address }),
+    tokenDetails: async (token, address) => {
+      const [symbol, decimals, balance] = await Promise.all([
+        client.readContract({
+          address: token,
+          abi: erc20Abi,
+          functionName: 'symbol',
+        }),
+        client.readContract({
+          address: token,
+          abi: erc20Abi,
+          functionName: 'decimals',
+        }),
+        client.readContract({
+          address: token,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [address],
+        }),
+      ]);
+      return { symbol, decimals, balance };
+    },
+    simulateToken: async (call) => {
+      const response = await client.call(call);
+      // Some widely used ERC-20 contracts return no value. Explicit false or
+      // malformed return data must not be mistaken for a successful transfer.
+      if (response.data && response.data !== '0x') {
+        const success = decodeFunctionResult({
+          abi: erc20Abi,
+          functionName: 'transfer',
+          data: response.data,
+        });
+        if (!success) {
+          throw new Error('Token transfer simulation returned false.');
+        }
+      }
+    },
+    // This installed viem version estimates L1 data + L2 execution fees.
+    // It is an estimate, not a guaranteed final fee or support for sponsored gas.
+    estimateFee: (call) => estimateTotalFee(client, { ...call, chain: base }),
+  };
+}
+
+export function parseTransferAmount(amount: string, decimals: number) {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 255) {
+    throw new Error('Token decimals are invalid.');
+  }
+  const normalized = amount.trim();
+  if (!/^\d+(\.\d+)?$/.test(normalized)) {
+    throw new Error('Enter a positive decimal amount.');
+  }
+  if ((normalized.split('.')[1]?.length ?? 0) > decimals) {
+    throw new Error(`This asset supports at most ${decimals} decimal places.`);
+  }
+  const units = parseUnits(normalized, decimals);
+  if (units <= 0n) {
+    throw new Error('Amount must be greater than zero.');
+  }
+  return units;
+}
+
+export async function prepareBaseTransfer(
+  reader: BaseTransferReader,
+  input: BaseTransferInput,
+): Promise<PreparedBaseTransfer> {
+  const recipient = input.recipient.trim();
+  if (!isAddress(recipient) || recipient.toLowerCase() === zeroAddress) {
+    throw new Error('Enter a valid, non-zero recipient address.');
+  }
+  const tokenAddress = input.tokenAddress;
+  if (
+    tokenAddress &&
+    (!isAddress(tokenAddress) ||
+      tokenAddress.toLowerCase() === zeroAddress ||
+      tokenAddress.toLowerCase() ===
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+  ) {
+    throw new Error('Choose a valid Base ERC-20 contract.');
+  }
+  const nativeBalance = await reader.nativeBalance(input.address);
+  const details = tokenAddress
+    ? await reader.tokenDetails(tokenAddress, input.address)
+    : {
+        symbol: base.nativeCurrency.symbol,
+        decimals: base.nativeCurrency.decimals,
+        balance: nativeBalance,
+      };
+  const units = parseTransferAmount(input.amount, details.decimals);
+  if (units > details.balance) {
+    throw new Error(
+      `Insufficient ${details.symbol} balance. Available: ${formatUnits(details.balance, details.decimals)} ${details.symbol} on Base.`,
+    );
+  }
+  const call: TransferCall = {
+    account: input.address,
+    to: tokenAddress ?? getAddress(recipient),
+    value: tokenAddress ? 0n : units,
+    ...(tokenAddress
+      ? {
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: 'transfer',
+            args: [getAddress(recipient), units],
+          }),
+        }
+      : {}),
+  };
+  if (tokenAddress) {
+    await reader.simulateToken(call);
+  }
+  const estimatedFee = await reader.estimateFee(call);
+  if (estimatedFee < 0n) {
+    throw new Error('Invalid network fee estimate.');
+  }
+  const feeReserve = (estimatedFee * 120n + 99n) / 100n;
+  if (nativeBalance < call.value + feeReserve) {
+    throw new Error(
+      'Not enough ETH on Base for this send and estimated gas (including a 20% fee buffer).',
+    );
+  }
+  return {
+    input: { ...input, recipient: getAddress(recipient) },
+    call,
+    units,
+    decimals: details.decimals,
+    symbol: details.symbol,
+    balance: details.balance,
+    estimatedFee,
+    preparedAt: Date.now(),
+  };
+}
+
+export async function submitBaseTransfer({
+  provider,
+  reader,
+  prepared,
+  isCurrent = () => true,
+}: {
+  provider: Pick<Provider.Provider, 'request'>;
+  reader: BaseTransferReader;
+  prepared: PreparedBaseTransfer;
+  isCurrent?: () => boolean;
+}) {
+  const assertCurrent = () => {
+    if (!isCurrent()) {
+      throw new Error('Wallet or form changed. Review the send again.');
+    }
+    if (Date.now() - prepared.preparedAt > 60_000) {
+      throw new Error('Review expired. Refresh the review before sending.');
+    }
+  };
+  assertCurrent();
+  await ensureBaseWalletAccount(provider, prepared.input.address);
+  assertCurrent();
+  const fresh = await prepareBaseTransfer(reader, prepared.input);
+  if (
+    fresh.units !== prepared.units ||
+    fresh.decimals !== prepared.decimals ||
+    fresh.call.to !== prepared.call.to ||
+    fresh.call.data !== prepared.call.data ||
+    fresh.call.value !== prepared.call.value
+  ) {
+    throw new Error('Token details changed. Review the send again.');
+  }
+  // A miniapp may have changed networks while the live checks were running.
+  await ensureBaseWalletAccount(provider, prepared.input.address, false);
+  assertCurrent();
+  return provider.request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        from: prepared.input.address,
+        to: fresh.call.to,
+        value: toHex(fresh.call.value),
+        ...(fresh.call.data ? { data: fresh.call.data } : {}),
+        chainId: toHex(base.id),
+      },
+    ],
+  });
+}

--- a/apps/farcaster-web/src/utils/lifiSwap.ts
+++ b/apps/farcaster-web/src/utils/lifiSwap.ts
@@ -1,0 +1,105 @@
+import { Address, isAddress, zeroAddress } from 'viem';
+import { base } from 'viem/chains';
+
+import { LifiAsset, requestLifi } from '~/utils/lifiWallet';
+
+export type LifiQuote = {
+  tool: string;
+  action: {
+    fromChainId: number;
+    toChainId: number;
+    fromAddress: Address;
+    toAddress: Address;
+    fromAmount: string;
+    fromToken: { chainId: number; address: Address; decimals: number };
+    toToken: { chainId: number; address: Address; decimals: number };
+  };
+  estimate: {
+    toAmount: string;
+    toAmountMin: string;
+    approvalAddress?: Address;
+  };
+  transactionRequest: {
+    chainId: number;
+    from: Address;
+    to: Address;
+    data: `0x${string}`;
+    value?: `0x${string}`;
+    gasLimit?: `0x${string}`;
+    gasPrice?: `0x${string}`;
+  };
+};
+
+export function validateLifiQuote(
+  quote: LifiQuote,
+  wallet: Address,
+  from: LifiAsset,
+  to: LifiAsset,
+  amount: bigint,
+) {
+  const same = (a: string | undefined, b: string) =>
+    typeof a === 'string' && a.toLowerCase() === b.toLowerCase();
+  const units = (value: unknown) =>
+    typeof value === 'string' && /^\d+$/.test(value);
+  if (
+    !quote?.action ||
+    !quote.estimate ||
+    !quote.transactionRequest ||
+    quote.action.fromChainId !== base.id ||
+    quote.action.toChainId !== base.id ||
+    quote.action.fromToken?.chainId !== base.id ||
+    quote.action.toToken?.chainId !== base.id ||
+    !same(quote.action.fromAddress, wallet) ||
+    !same(quote.action.toAddress, wallet) ||
+    !same(quote.action.fromToken?.address, from.address) ||
+    !same(quote.action.toToken?.address, to.address) ||
+    quote.action.fromToken.decimals !== from.decimals ||
+    quote.action.toToken.decimals !== to.decimals ||
+    !units(quote.action.fromAmount) ||
+    BigInt(quote.action.fromAmount) !== amount ||
+    !units(quote.estimate.toAmount) ||
+    !units(quote.estimate.toAmountMin) ||
+    BigInt(quote.estimate.toAmountMin) <= 0n ||
+    BigInt(quote.estimate.toAmountMin) > BigInt(quote.estimate.toAmount) ||
+    quote.transactionRequest.chainId !== base.id ||
+    !same(quote.transactionRequest.from, wallet) ||
+    !isAddress(quote.transactionRequest.to) ||
+    quote.transactionRequest.to === zeroAddress ||
+    typeof quote.transactionRequest.data !== 'string' ||
+    !/^0x(?:[a-fA-F0-9]{2})+$/.test(quote.transactionRequest.data) ||
+    (quote.estimate.approvalAddress &&
+      (!isAddress(quote.estimate.approvalAddress) ||
+        quote.estimate.approvalAddress === zeroAddress))
+  ) {
+    throw new Error(
+      'LI.FI quote does not match this Base swap. Request a new quote.',
+    );
+  }
+  const value = BigInt(quote.transactionRequest.value ?? '0');
+  if (value < 0n || (from.address === zeroAddress && value < amount)) {
+    throw new Error('Invalid LI.FI transaction value.');
+  }
+}
+
+export async function fetchLifiQuote(
+  wallet: Address,
+  from: LifiAsset,
+  to: LifiAsset,
+  amount: bigint,
+) {
+  const params = new URLSearchParams({
+    fromChain: String(base.id),
+    toChain: String(base.id),
+    fromToken: from.address,
+    toToken: to.address,
+    fromAmount: amount.toString(),
+    fromAddress: wallet,
+    toAddress: wallet,
+    slippage: '0.005',
+    order: 'CHEAPEST',
+    integrator: 'farcaster-wallet-client',
+  });
+  const quote = (await requestLifi(`/quote?${params}`)) as LifiQuote;
+  validateLifiQuote(quote, wallet, from, to, amount);
+  return quote;
+}

--- a/apps/farcaster-web/src/utils/lifiWallet.ts
+++ b/apps/farcaster-web/src/utils/lifiWallet.ts
@@ -1,0 +1,231 @@
+import {
+  Address,
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  isAddress,
+  PublicClient,
+  zeroAddress,
+} from 'viem';
+import { base } from 'viem/chains';
+
+export const LIFI_API_URL = 'https://li.quest/v1';
+export const LIFI_NATIVE_ADDRESS = zeroAddress;
+export type LifiToken = {
+  chainId: number;
+  address: Address;
+  symbol: string;
+  name: string;
+  decimals: number;
+  priceUSD?: number;
+  verificationStatus?: string;
+};
+export type LifiAsset = LifiToken & { balance: bigint };
+export const BASE_NATIVE_TOKEN: LifiToken = {
+  chainId: base.id,
+  address: zeroAddress,
+  symbol: 'ETH',
+  name: 'Ether',
+  decimals: 18,
+};
+
+export function normalizeLifiAddress(value: string): Address {
+  const input = value.trim();
+  if (
+    input.toUpperCase() === 'ETH' ||
+    input.toLowerCase() === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+  ) {
+    return zeroAddress;
+  }
+  if (!isAddress(input)) {
+    throw new Error('Enter ETH or a valid Base token contract address.');
+  }
+  return getAddress(input);
+}
+
+export const lifiWalletKey = (address: Address) =>
+  ['lifiWallet', base.id, address.toLowerCase()] as const;
+export const lifiTokenKey = (token: Address) =>
+  ['lifiToken', base.id, normalizeLifiAddress(token).toLowerCase()] as const;
+export const lifiBalanceKey = (address: Address, token: Address) =>
+  [
+    ...lifiWalletKey(address),
+    'balance',
+    normalizeLifiAddress(token).toLowerCase(),
+  ] as const;
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid LI.FI response.');
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseLifiToken(value: unknown): LifiToken {
+  const token = object(value);
+  if (
+    token.chainId !== base.id ||
+    typeof token.address !== 'string' ||
+    !isAddress(token.address) ||
+    typeof token.decimals !== 'number' ||
+    !Number.isInteger(token.decimals) ||
+    token.decimals < 0 ||
+    token.decimals > 255 ||
+    typeof token.symbol !== 'string' ||
+    !token.symbol.trim()
+  ) {
+    throw new Error('Invalid Base token in LI.FI response.');
+  }
+  const price =
+    typeof token.priceUSD === 'string' && token.priceUSD.trim() !== ''
+      ? Number(token.priceUSD)
+      : token.priceUSD;
+  return {
+    chainId: base.id,
+    address: normalizeLifiAddress(token.address),
+    symbol: token.symbol,
+    name: typeof token.name === 'string' ? token.name : token.symbol,
+    decimals: token.decimals,
+    priceUSD:
+      typeof price === 'number' && Number.isFinite(price) && price >= 0
+        ? price
+        : undefined,
+    verificationStatus:
+      typeof token.verificationStatus === 'string'
+        ? token.verificationStatus
+        : undefined,
+  };
+}
+
+export async function requestLifi(
+  path: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const cancel = () => controller.abort();
+  if (signal?.aborted) {
+    cancel();
+  }
+  signal?.addEventListener('abort', cancel, { once: true });
+  const timeout = setTimeout(cancel, 20_000);
+  try {
+    const response = await fetch(`${LIFI_API_URL}${path}`, {
+      signal: controller.signal,
+      credentials: 'omit',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(
+        response.status === 429
+          ? 'LI.FI is rate limiting requests. Please try again shortly.'
+          : `LI.FI request failed (${response.status}). Please try again.`,
+      );
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener('abort', cancel);
+  }
+}
+
+export async function fetchLifiWalletTokens(
+  address: Address,
+  signal?: AbortSignal,
+) {
+  const body = object(
+    await requestLifi(
+      `/wallets/${address.toLowerCase()}/balances?extended=true`,
+      signal,
+    ),
+  );
+  if (
+    typeof body.walletAddress !== 'string' ||
+    body.walletAddress.toLowerCase() !== address.toLowerCase()
+  ) {
+    throw new Error('LI.FI returned a different wallet.');
+  }
+  const balances = object(body.balances);
+  const rows = balances[base.id] ?? [];
+  if (!Array.isArray(rows)) {
+    throw new Error('Invalid LI.FI Base balances.');
+  }
+  const tokens = new Map<string, LifiToken>();
+  let skipped = 0;
+  for (const row of rows) {
+    try {
+      const token = parseLifiToken(row);
+      tokens.set(token.address.toLowerCase(), token);
+    } catch {
+      skipped += 1;
+    }
+  }
+  // Indexed amounts are deliberately not copied into the spendable balance
+  // cache. Every screen uses the same live balance query instead.
+  const total = Object.values(balances).reduce<number>(
+    (count, entries) => count + (Array.isArray(entries) ? entries.length : 0),
+    0,
+  );
+  return {
+    tokens: [...tokens.values()],
+    skipped,
+    possiblyLimited: typeof body.limit === 'number' && total >= body.limit,
+  };
+}
+
+export async function fetchLifiToken(address: Address, signal?: AbortSignal) {
+  const token = parseLifiToken(
+    await requestLifi(`/token?chain=${base.id}&token=${address}`, signal),
+  );
+  if (
+    token.address.toLowerCase() !== normalizeLifiAddress(address).toLowerCase()
+  ) {
+    throw new Error('LI.FI returned a different token.');
+  }
+  return token;
+}
+
+export async function readLifiAsset(
+  client: PublicClient,
+  wallet: Address,
+  token: LifiToken,
+): Promise<LifiAsset> {
+  if (client.chain?.id !== base.id || token.chainId !== base.id) {
+    throw new Error('Base RPC is required.');
+  }
+  if (token.address === zeroAddress) {
+    return { ...token, balance: await client.getBalance({ address: wallet }) };
+  }
+  const [decimals, balance] = await Promise.all([
+    client.readContract({
+      address: token.address,
+      abi: erc20Abi,
+      functionName: 'decimals',
+    }),
+    client.readContract({
+      address: token.address,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [wallet],
+    }),
+  ]);
+  if (decimals !== token.decimals) {
+    throw new Error(
+      'Token decimals disagree with LI.FI. Refresh token data before using this asset.',
+    );
+  }
+  return { ...token, balance };
+}
+
+export function lifiAssetUsd(asset: LifiAsset): number | undefined {
+  if (asset.priceUSD === undefined) {
+    return undefined;
+  }
+  const value =
+    Number(formatUnits(asset.balance, asset.decimals)) * asset.priceUSD;
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export function formatLifiBalance(asset: LifiAsset): string {
+  return formatUnits(asset.balance, asset.decimals);
+}

--- a/apps/farcaster-web/src/utils/readConfirmedAllowance.ts
+++ b/apps/farcaster-web/src/utils/readConfirmedAllowance.ts
@@ -1,0 +1,57 @@
+// Only retry missing-block errors. A successful low allowance, contract revert,
+// or unrelated RPC failure must not be mistaken for a lagging block.
+function isMissingBlock(error: unknown): boolean {
+  const visited = new Set<unknown>();
+  let current = error;
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    const details = current as {
+      message?: unknown;
+      details?: unknown;
+      cause?: unknown;
+    };
+    if (
+      [details.message, details.details].some(
+        (value) =>
+          typeof value === 'string' &&
+          /block not found|unknown block|header not found/i.test(value),
+      )
+    ) {
+      return true;
+    }
+    current = details.cause;
+  }
+  return false;
+}
+
+export async function readConfirmedAllowance({
+  read,
+  assertCurrent,
+  onRetry,
+}: {
+  read: () => Promise<bigint>;
+  assertCurrent: () => void;
+  onRetry: () => void;
+}): Promise<bigint> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    assertCurrent();
+    try {
+      const allowance = await read();
+      assertCurrent();
+      return allowance;
+    } catch (error) {
+      assertCurrent();
+      if (!isMissingBlock(error)) {
+        throw error;
+      }
+      if (attempt === 7) {
+        throw new Error(
+          'Approval confirmed, but Base RPC could not read its block yet. Wait a moment and get a new quote. No swap was sent.',
+        );
+      }
+      onRetry();
+      await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+    }
+  }
+  throw new Error('Could not verify token allowance. No swap was sent.');
+}

--- a/apps/farcaster-web/src/utils/sendBaseNativeToken.ts
+++ b/apps/farcaster-web/src/utils/sendBaseNativeToken.ts
@@ -15,9 +15,28 @@ export async function sendBaseNativeToken({
   recipient: Address;
   value: bigint;
 }) {
+  await ensureBaseWalletAccount(provider, address);
+  return provider.request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        from: address,
+        to: recipient,
+        value: toHex(value),
+        chainId: toHex(base.id),
+      },
+    ],
+  });
+}
+
+export async function ensureBaseWalletAccount(
+  provider: Pick<Provider.Provider, 'request'>,
+  address: Address,
+  allowSwitch = true,
+) {
   const chainId = toHex(base.id);
   const currentChainId = await provider.request({ method: 'eth_chainId' });
-  if (Number(currentChainId) !== base.id) {
+  if (Number(currentChainId) !== base.id && allowSwitch) {
     await provider.request({
       method: 'wallet_switchEthereumChain',
       params: [{ chainId }],
@@ -34,9 +53,4 @@ export async function sendBaseNativeToken({
   if (Number(verifiedChainId) !== base.id) {
     throw new Error('Wallet is not on Base. No transaction was submitted.');
   }
-
-  return provider.request({
-    method: 'eth_sendTransaction',
-    params: [{ from: address, to: recipient, value: toHex(value), chainId }],
-  });
 }

--- a/apps/farcaster-web/src/utils/sendBaseNativeToken.ts
+++ b/apps/farcaster-web/src/utils/sendBaseNativeToken.ts
@@ -1,0 +1,42 @@
+import { Provider } from 'ox';
+import { Address, toHex } from 'viem';
+import { base } from 'viem/chains';
+
+// Only dashboard sends use this guard. Miniapps keep their existing provider
+// and may request other networks without the dashboard switching them back.
+export async function sendBaseNativeToken({
+  provider,
+  address,
+  recipient,
+  value,
+}: {
+  provider: Pick<Provider.Provider, 'request'>;
+  address: Address;
+  recipient: Address;
+  value: bigint;
+}) {
+  const chainId = toHex(base.id);
+  const currentChainId = await provider.request({ method: 'eth_chainId' });
+  if (Number(currentChainId) !== base.id) {
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId }],
+    });
+  }
+
+  // A switch prompt can stay open while the user changes accounts. Require
+  // the account that was used to prepare the send, rather than substituting it.
+  const accounts = await provider.request({ method: 'eth_accounts' });
+  if (accounts[0]?.toLowerCase() !== address.toLowerCase()) {
+    throw new Error('Wallet account changed. Review the send again.');
+  }
+  const verifiedChainId = await provider.request({ method: 'eth_chainId' });
+  if (Number(verifiedChainId) !== base.id) {
+    throw new Error('Wallet is not on Base. No transaction was submitted.');
+  }
+
+  return provider.request({
+    method: 'eth_sendTransaction',
+    params: [{ from: address, to: recipient, value: toHex(value), chainId }],
+  });
+}

--- a/apps/farcaster-web/src/utils/wagmi.ts
+++ b/apps/farcaster-web/src/utils/wagmi.ts
@@ -1,3 +1,4 @@
+import { walletConnect } from '@wagmi/connectors';
 import { robinhood } from 'farcaster-client-data';
 import { bsc, degen, monadTestnet, unichain } from 'viem/chains';
 import { Config, createConfig, http, Transport } from 'wagmi';
@@ -44,10 +45,31 @@ const transports = chains.reduce(
   {} as Record<number, Transport>,
 );
 
+const walletConnectProjectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID;
+const appOrigin =
+  typeof window === 'undefined'
+    ? ['https:', '//farcaster.xyz'].join('')
+    : window.location.origin;
+
+const connectors = walletConnectProjectId
+  ? [
+      walletConnect({
+        projectId: walletConnectProjectId,
+        metadata: {
+          name: 'Farcaster Wallet Client',
+          description: 'Farcaster client with external wallet support',
+          url: appOrigin,
+          icons: [`${appOrigin}/favicon-v3.png`],
+        },
+        showQrModal: true,
+      }),
+    ]
+  : [];
+
 const wagmiConfig: Config = createConfig({
   chains,
   transports,
-  connectors: [],
+  connectors,
 });
 
 export { wagmiConfig };

--- a/functions/~api/[[path]].ts
+++ b/functions/~api/[[path]].ts
@@ -1,0 +1,96 @@
+const upstreamOrigin = 'https://farcaster.xyz';
+
+const supportedMethods = new Set([
+  'DELETE',
+  'GET',
+  'HEAD',
+  'PATCH',
+  'POST',
+  'PUT',
+]);
+
+const requestHeadersToRemove = [
+  'cf-connecting-ip',
+  'cf-ipcountry',
+  'cf-ray',
+  'cf-visitor',
+  'connection',
+  'cookie',
+  'host',
+  'origin',
+  'referer',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+];
+
+const responseHeadersToRemove = [
+  'access-control-allow-credentials',
+  'access-control-allow-headers',
+  'access-control-allow-methods',
+  'access-control-allow-origin',
+  'set-cookie',
+];
+
+type PagesFunctionContext = {
+  request: Request;
+};
+
+/**
+ * Same-origin relay for Farcaster's fixed API host.
+ *
+ * Callers cannot choose the host or path prefix, so this is not a general
+ * proxy. Authorization and Farcaster device headers pass through transiently;
+ * cookies and forwarding metadata are removed and nothing is persisted.
+ */
+const onRequest = async ({
+  request,
+}: PagesFunctionContext): Promise<Response> => {
+  if (!supportedMethods.has(request.method)) {
+    return new Response('Method not allowed', {
+      status: 405,
+      headers: { Allow: [...supportedMethods].join(', ') },
+    });
+  }
+
+  const incomingUrl = new URL(request.url);
+  if (
+    incomingUrl.pathname !== '/~api' &&
+    !incomingUrl.pathname.startsWith('/~api/')
+  ) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const upstreamUrl = new URL(
+    `${incomingUrl.pathname}${incomingUrl.search}`,
+    upstreamOrigin,
+  );
+  const upstreamHeaders = new Headers(request.headers);
+  for (const header of requestHeadersToRemove) {
+    upstreamHeaders.delete(header);
+  }
+
+  const upstreamResponse = await fetch(upstreamUrl, {
+    method: request.method,
+    headers: upstreamHeaders,
+    body:
+      request.method === 'GET' || request.method === 'HEAD'
+        ? undefined
+        : request.body,
+    redirect: 'manual',
+  });
+
+  const responseHeaders = new Headers(upstreamResponse.headers);
+  for (const header of responseHeadersToRemove) {
+    responseHeaders.delete(header);
+  }
+  responseHeaders.set('Cache-Control', 'no-store');
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+};
+
+export { onRequest };


### PR DESCRIPTION
## Summary

Completes the Base-only external wallet experience with a token portfolio, native ETH and ERC-20 sends, and a two-step approval and swap flow.

## Changes

- LI.FI token discovery and estimated pricing, with on-chain balances shared across Portfolio, Send and Trade.
- ETH and native Base USDC as default buy options.
- Wallet-token selection and custom contract entry.
- Visible approved and required amounts for the swap spender.
- Exact-amount approvals, confirmation waiting and a separate swap review step.
- Bounded retries when the RPC cannot yet read the confirmed approval block.
- Cleaner portfolio layout, loading indicators and refresh feedback.
- Updated setup documentation and regression tests.

## Validation

- 351 tests passed across the web app.
- TypeScript, ESLint and production build passed.
- Manual wallet testing covered token selection, approval prompts, allowance display and rejection handling.

## Scope

Base only. Signing and custody remain with the connected external wallet. Token discovery and pricing depend on LI.FI; balances depend on Base RPC availability.